### PR TITLE
Disable rspec nil warning

### DIFF
--- a/spec/controllers/volunteer_ops_controller_spec.rb
+++ b/spec/controllers/volunteer_ops_controller_spec.rb
@@ -111,7 +111,10 @@ describe VolunteerOpsController do
 
     describe '#org_owner?' do
       context 'when current user is nil' do
-        before { controller.stub current_user: nil }
+        before :each do 
+          allow_message_expectations_on_nil
+          controller.stub current_user: nil
+        end
 
         it 'returns false' do
           controller.instance_eval { org_owner? }.should be_false


### PR DESCRIPTION
Rspec was spitting out a warning message in a controller example. Please expand the commit message for details.
