### PR TITLE
Allow interactive jasmine specs for vagrant devs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,8 +7,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "hashicorp/precise32"
   config.vm.provision "shell", path: "vagrant-ubuntu-install.sh", privileged: false
   config.vm.network :forwarded_port, host: 3003, guest: 3000
-  #view http://localhost:3004 after runing rake jasmine in vagrant to view interactive jasmine specs on host
-  config.vm.network :forwarded_port, host: 3004, guest: 8888
+  #visit http://localhost:8888 after runing rake jasmine in vagrant to view interactive jasmine specs on host
+  config.vm.network :forwarded_port, host: 8888, guest: 8888
   config.vm.synced_folder ".", "/LocalSupport"
 
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
This is in the running for tiniest PR but it might be useful for vagrant devs.

This will allow a vagrant dev to run 'rake jasmine' in the vagrant vm and then on the host machine visit http://localhost:3004 and interactively view (and debug) jasmine specs.

I wasn't sure about the rationale for choosing other ports for the host machine port-forwarding (security?) so if 8888 on the host (which is the default and what prints in the terminal) seems more natural for the jasmine server, then let me know.
