### PR TITLE
bump capybara-webkit version to 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :test do
   gem 'minitest', '~> 4.7.1'
   gem 'ZenTest'
   gem 'capybara', '2.4.1'
-  gem "capybara-webkit", "~> 1.0.0"
+  gem "capybara-webkit", "~> 1.1.0"
   gem 'webrat'
   gem 'factory_girl_rails', :require => false
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.0.0)
+    capybara-webkit (1.1.0)
       capybara (~> 2.0, >= 2.0.2)
       json
     childprocess (0.5.3)
@@ -197,7 +197,7 @@ GEM
     multi_json (1.10.1)
     multi_test (0.0.2)
     newrelic_rpm (3.6.7.159)
-    nokogiri (1.6.3)
+    nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     orm_adapter (0.4.0)
     parallel (0.8.4)
@@ -341,7 +341,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap_sortable_rails (~> 0.1.3)
   capybara (= 2.4.1)
-  capybara-webkit (~> 1.0.0)
+  capybara-webkit (~> 1.1.0)
   coffee-rails
   cucumber-rails
   cucumber-rails-training-wheels


### PR DESCRIPTION
 for better debugging on "Failed to click element"
- gets a screenshot in /tmp including css, unlike 'show me the page'
- tells which overlapping element if any
