### PR TITLE
upgrade debugger to version ~> 1.6.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 
 group :development do
   #gem 'ruby-debug19', :require => 'ruby-debug'
-  gem 'debugger', '1.6.6'
+  gem 'debugger', '~> 1.6.8'
   gem 'railroady'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,12 +98,12 @@ GEM
       cucumber-rails (>= 1.1.1)
     database_cleaner (1.0.1)
     debug_inspector (0.0.2)
-    debugger (1.6.6)
+    debugger (1.6.8)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.2)
+      debugger-ruby_core_source (~> 1.3.5)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.2)
+    debugger-ruby_core_source (1.3.5)
     devise (3.0.3)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
@@ -346,7 +346,7 @@ DEPENDENCIES
   cucumber-rails
   cucumber-rails-training-wheels
   database_cleaner (= 1.0.1)
-  debugger (= 1.6.6)
+  debugger (~> 1.6.8)
   devise (= 3.0.3)
   devise_invitable (~> 1.2.1)
   execjs


### PR DESCRIPTION
Open PRs that triggered Travis recently broke because Travis upgraded their defaults, so debugger was not a good version.
https://github.com/AgileVentures/LocalSupport/pull/69

```
it had rvm 1.25.25 now 1.25.28
it had ruby-1.9.3-p545 now p547
it had rubygems 2.2.2 now 2.3.0
it had bundler 1.6.1 now 1.6.2
```

Update to version ~> 1.6.8 will freshen previous 1.6.6
