### PR TITLE
Align text to center in org info message

### DIFF
--- a/app/assets/stylesheets/organisations.css
+++ b/app/assets/stylesheets/organisations.css
@@ -23,3 +23,7 @@
     border-radius:2em;
     text-align: center;
 }
+
+.borderless {
+    border-top: none !important;
+}


### PR DESCRIPTION
This should fix the text outside of the color region bug.
