### PR TITLE
Bug fix for admin mailer template

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,7 +1,7 @@
 class AdminMailer < ActionMailer::Base
 
   def new_user_waiting_for_approval(org_name, admin_emails)
-    @org = Organisation.find_by_id org_name
+    @org_name = org_name
     mail(subject: "There is a User Waiting for Admin Approval to '#{org_name}'",
          to: admin_emails ,
          from: "support@harrowcn.org.uk",

--- a/app/views/admin_mailer/new_user_waiting_for_approval.html.erb
+++ b/app/views/admin_mailer/new_user_waiting_for_approval.html.erb
@@ -1,4 +1,4 @@
-There is a User Waiting for Admin Approval to '#{@org.name}'
+There is a User Waiting for Admin Approval to '<%= @org_name %>'
 
 Please log in to the admin interface in order to approve or decline their request
 

--- a/features/individual_charity_pages/this-is-my-org.feature
+++ b/features/individual_charity_pages/this-is-my-org.feature
@@ -23,7 +23,7 @@ Feature: This is my organisation
     Then I should see "You have requested admin status for Helpful Folk"
     And I should not see a link or button "This is my organisation"
     And "admin@helpfolk.com"'s request for "Helpful Folk" should be persisted
-    And an email should be sent to "admin@localsupport.org" as notification of the request
+    And an email should be sent to "admin@localsupport.org" as notification of the request for admin status of "Helpful Folk"
 
 # when capybara-webkit clicks TIMO, it needs to submit sign in form with javascript or
 # else ClickFailed error will occur due to overlapping elements
@@ -34,7 +34,7 @@ Feature: This is my organisation
     Then I should see "You have requested admin status for Helpful Folk"
     And I should not see a link or button "This is my organisation"
     And "admin@helpfolk.com"'s request for "Helpful Folk" should be persisted
-    And an email should be sent to "admin@localsupport.org" as notification of the request
+    And an email should be sent to "admin@localsupport.org" as notification of the request for admin status of "Helpful Folk"
 
 # what we're not checking here is that the login box pops open with the right message
 # I think we cover that in jasmine tests - needed here too?
@@ -47,7 +47,7 @@ Feature: This is my organisation
     Then I should see "You have requested admin status for Helpful Folk"
     And I should not see a link or button "This is my organisation"
     And "admin@helpfolk.com"'s request for "Helpful Folk" should be persisted
-    And an email should be sent to "admin@localsupport.org" as notification of the request
+    And an email should be sent to "admin@localsupport.org" as notification of the request for admin status of "Helpful Folk"
 
   @javascript
   Scenario: Unregistered User
@@ -61,7 +61,7 @@ Feature: This is my organisation
     And "normal_user@myorg.com"'s request for "Helpful Folk" should be persisted
     And I click on the confirmation link in the email to "normal_user@myorg.com"
     Then I should be on the show page for the organisation named "Helpful Folk"
-    And an email should be sent to "admin@localsupport.org" as notification of the request
+    And an email should be sent to "admin@localsupport.org" as notification of the request for admin status of "Helpful Folk"
 
   @javascript
   Scenario: Unregistered User Who Fails Signin Once
@@ -77,7 +77,7 @@ Feature: This is my organisation
     And "newuser@myorg.com"'s request for "Helpful Folk" should be persisted
     And I click on the confirmation link in the email to "newuser@myorg.com"
     Then I should be on the show page for the organisation named "Helpful Folk"
-    And an email should be sent to "admin@localsupport.org" as notification of the request
+    And an email should be sent to "admin@localsupport.org" as notification of the request for admin status of "Helpful Folk"
 
   Scenario: I have requested admin status but am not yet approved, I will see a notice only on the show page for the requested org
     Given I am signed in as a pending-admin of "Helpful Folk"

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -1,8 +1,9 @@
-And(/^an email should be sent to "(.*?)" as notification of the request$/) do |email|
-  mails = ActionMailer::Base.deliveries
+And(/^an email should be sent to "(.*?)" as notification of the request for admin status of "(.*?)"$/) do |email, org_name|
+  message = "There is a User Waiting for Admin Approval to '#{org_name}'"
+  mails = ActionMailer::Base.deliveries.select{|m| m.to.include? email}
   expect(mails).not_to be_empty
-  tos = mails.map {|m| m.to}
-  expect(tos).to include [email]
+  bodys = mails.map{|m| m.body}.select{|body| body.include? message }
+  expect(bodys).not_to be_empty
 end
 
 And /^I should receive a "(.*?)" email$/ do |arg1|

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe AdminMailer do
-
   subject{AdminMailer.new_user_waiting_for_approval('friendly', 'admin@admin.org')}
 
   it{ expect{subject.deliver}.to change{ActionMailer::Base.deliveries.length}.by(1)}

--- a/spec/views/admin_mailer/new_user_waiting_for_approval.html_spec.rb
+++ b/spec/views/admin_mailer/new_user_waiting_for_approval.html_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'admin_mailer/new_user_waiting_for_approval.html.erb' do
+  it 'should render with org name' do
+    assign(:org_name, 'Friendly')
+    render
+    render.should have_content("There is a User Waiting for Admin Approval to 'Friendly'")
+  end
+end


### PR DESCRIPTION
The bug is noted [here](https://www.pivotaltracker.com/story/show/80074682).

Basically, the admin mailer template didn't respect erb convention where code that is display is written between <%= %>
