### PR TITLE
Fix bug in new org creation

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -41,6 +41,7 @@ class OrganisationsController < ApplicationController
   # GET /organisations/new.json
   def new
     @organisation = Organisation.new
+    @categories_start_with = Category.first_category_name_in_each_type
   end
 
   # GET /organisations/1/edit

--- a/features/admin/admin_new_charity.feature
+++ b/features/admin/admin_new_charity.feature
@@ -12,6 +12,18 @@ Feature: Admin creating charity
       | email                         | password | admin | confirmed_at         | organisation |
       | registered-user-1@example.com | pppppppp | true  | 2007-01-01  10:00:00 | Friendly     |
       | registered-user-2@example.com | pppppppp | false | 2007-01-01  10:00:00 |              |
+    And the following categories exist:
+      | name              | charity_commission_id |
+      | Animal welfare    | 101                   |
+      | Child welfare     | 102                   |
+      | Feed the hungry   | 103                   |
+      | Accommodation     | 203                   |
+      | General           | 204                   |
+      | Health            | 202                   |
+      | Education         | 303                   |
+      | Give them things  | 304                   |
+      | Teach them things | 305                   |
+ 
     And cookies are approved
 
   Scenario: Unsuccessfully attempt to create charity without being signed-in
@@ -38,9 +50,15 @@ Feature: Admin creating charity
     Given I am signed in as a admin
     Given I visit the show page for the organisation named "Friendly Clone"
     And I follow "New Organisation"
-    And I fill in the new charity page validly
+    And I fill in the new charity page validly including the categories:
+    | name           |
+    | Feed the hungry|
+    | Accommodation  |
     And I press "Create Organisation"
     Then I should see "Organisation was successfully created."
+    And I should see "Feed the hungry"
+    And I should see "Accommodation"
+    And I should not see "General"
 
   Scenario: Non-admin unsuccessfully attempts to create an organisation
     Given I am signed in as a non-admin

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -77,7 +77,17 @@ When /^I search for "(.*?)"$/ do |text|
   click_button 'Submit'
 end
 
-Given /^I fill in the new charity page validly$/ do
+Given (/^I fill in the new charity page validly$/) do
+  stub_request_with_address("64 pinner road")
+  fill_in 'organisation_address', :with => '64 pinner road'
+  fill_in 'organisation_name', :with => 'Friendly charity'
+end
+Given (/^I fill in the new charity page validly including the categories:$/) do |categories_table|
+  categories_table.hashes.each do |cat|
+    steps %Q{
+      And I check the category "#{cat[:name]}"
+    }
+  end
   stub_request_with_address("64 pinner road")
   fill_in 'organisation_address', :with => '64 pinner road'
   fill_in 'organisation_name', :with => 'Friendly charity'


### PR DESCRIPTION
So on develop, there was a bug for creating a new org -- the _form partial would crash on new org creation if there were categories in the database, since a certain instance variable wasn't set properly in the new method of the controller.

Regression testing failed to pick it up since the old feature for creating new charities did not have categories in their backgrounds and thus represented an out of date and unrealistic database state.
