### PR TITLE
Fix map view for google landmarks, eg. hospital

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -286,7 +286,6 @@ div#container textarea {
 }
 
 .gm-style-iw {
-  width: auto !important;
   height: auto !important;
   padding-right: 3em;
 }


### PR DESCRIPTION
This pr fixes the issue with the truncated info window that cut off part of the street view for google landmarks. On production, we had harrow hospital with street view upon clicking all along; it was just obstructed from view by a large default icon.

Staged here:

https://small-icons.herokuapp.com/
