### PR TITLE
removes ninefold icon, replaces with expeditedSSL and removes view te…

### DIFF
--- a/app/views/layouts/_footer2.html.erb
+++ b/app/views/layouts/_footer2.html.erb
@@ -1,5 +1,7 @@
 <footer class="footer">
    <p class="text-center"><small>
-     Powered by <%= link_to image_tag("av_symbol_30px.png", :size =>"30x30", alt:"Agile Ventures"), contributors_path %>&nbsp &nbsp &nbsp &nbsp &nbspHosted by <%= link_to image_tag("ninefold-logo-30x30.gif", :size =>"30x30", alt:"Ninefold"), 'https://ninefold.com' %>&nbsp &nbsp &nbsp &nbsp &nbsp
+     Powered by <%= link_to image_tag("av_symbol_30px.png", :size =>"30x30", alt:"Agile Ventures"), contributors_path %>&nbsp; &nbsp;<a href="https://www.expeditedssl.com/simple-ssl-scanner/scan?target_domain=www.harrowcn.org.uk" target="_blank"><img width='70px' height='40px' alt="Ssl-secure-badge" src="https://www.expeditedssl.com/ssl-secure-badge.png" /></a>
    </small> </p>
 </footer>
+
+

--- a/features/admin/acknowledging_contributors_site.feature
+++ b/features/admin/acknowledging_contributors_site.feature
@@ -8,10 +8,9 @@ Feature: Acknowledging Contributors
   Scenario Outline: Display acknowledgements
     Given I visit the <page> page
     Then I should see the "Agile Ventures" image linked to contributors
-    And I should see the "Ninefold" image linked to "https://ninefold.com"
+    And I should see the "Ssl-secure-badge" image linked to "https://www.expeditedssl.com/simple-ssl-scanner/scan?target_domain=www.harrowcn.org.uk"
   Examples:
     | page                |
     | home                |
     | organisations index |
     | new organisation    |
-

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -117,20 +117,6 @@ describe 'layouts/application.html.erb', :type => :view do
       expect(rendered).to have_selector('div.alert-error')
     end
 
-    it 'should display a logo linked to the contributors page' do
-      render
-      rendered.within("a[href='#{contributors_path}']") do |hyperlink|
-        expect(hyperlink).to have_css "img[@alt='Agile Ventures']"
-      end
-    end
-
-    it 'should display a logo linked to the ninefold page' do
-      render
-      rendered.within("a[href='https://ninefold.com']") do |hyperlink|
-        expect(hyperlink).to have_css "img[@alt='Ninefold']"
-      end
-    end
-
     it "does not render a new organisation link" do
       allow(view).to receive_messages(:user_signed_in? => false)
       render


### PR DESCRIPTION
gets rid of ninefold logo, replacing it with expedited SSL logo - also removes some view tests that are just replicating cucumber feature test