### PR TITLE
Fix spacing on org show page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,6 +449,3 @@ DEPENDENCIES
   uri-handler
   url_validator
   webmock (= 1.20.0)
-
-BUNDLED WITH
-   1.10.3

--- a/app/assets/stylesheets/gmaps4rails.css.scss
+++ b/app/assets/stylesheets/gmaps4rails.css.scss
@@ -9,6 +9,7 @@
   -moz-box-shadow: rgba(64, 64, 64, 0.5) 0 2px 5px;
   box-shadow: rgba(64, 64, 64, 0.1) 0 2px 5px;
   margin-bottom: 20px; // for when the screen narrows to a one column layout
+  margin-right: 2%;
 }
 
 .map_container img {


### PR DESCRIPTION
This will set the spacing back on the org show page so that there is space between the map and the informational column.