### PR TITLE
Issue found in compatibility with capybara-webkit and qt5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :test do
   gem 'cucumber-rails', :require => false
   gem 'cucumber-rails-training-wheels'
   gem 'capybara', '2.4.1'
-  gem "capybara-webkit", "~> 1.1.0"
+  gem "capybara-webkit", "~> 1.6.0"
   gem 'factory_girl_rails', :require => false
   gem 'webmock', '1.20.0'
   gem 'uri-handler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,8 +63,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.1.0)
-      capybara (~> 2.0, >= 2.0.2)
+    capybara-webkit (1.6.0)
+      capybara (>= 2.3.0, < 2.5.0)
       json
     childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
@@ -405,7 +405,7 @@ DEPENDENCIES
   bootstrap_sortable_rails (~> 0.1.3)
   byebug
   capybara (= 2.4.1)
-  capybara-webkit (~> 1.1.0)
+  capybara-webkit (~> 1.6.0)
   coffee-rails (= 4.1.0)
   cucumber-rails
   cucumber-rails-training-wheels


### PR DESCRIPTION
I found one issue between capybara-webkit 1.1.0 and qt5 that is described here:
https://github.com/thoughtbot/capybara-webkit/issues/724

To solve it I did as suggested to update to a newer version of capybara-webkit and in my machine all the cucs run with any error now