### PR TITLE
Make cukes use fake sinatra app for geocoding

### DIFF
--- a/config/initializers/webmock.rb
+++ b/config/initializers/webmock.rb
@@ -6,9 +6,6 @@ if ENV["RAILS_ENV"] == 'test'
   # Stub out network calls and return fixtures with sinatra's help
   WebMock.disable_net_connect!(allow_localhost: true)
   require "#{Rails.root}/test/fake_google_geocode"
-  # if ENV['CUCUMBER']
-  #   Before { stub_google_maps }
-  # end
   if ENV['RSPEC']
     RSpec.configure {|r| r.before(:each) { stub_google_maps } }
   end

--- a/features/admin/admin_moderate_proposed_organisation_edits.feature
+++ b/features/admin/admin_moderate_proposed_organisation_edits.feature
@@ -4,10 +4,6 @@ Feature: Members of HCN may propose edits to organisations
   I want to be able to moderate proposed edits to organisations listed on the HCN
 
   Background: organisations have been added to database
-    Given the following addresses exist:
-      | address                 |
-      | 30 pinner road          |
-      | 34 pinner road          |
     Given the following organisations exist:
       | name              | description             | address        | publish_address | postcode | telephone | website             | email             | publish_phone |donation_info  | publish_email |
       | Friendly          | Bereavement Counselling | 30 pinner road | true            |HA1 4HZ   | 020800000 | http://friendly.org | superadmin@friendly.xx | true          |www.donate.com | true          |

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -83,7 +83,6 @@ When /^I search for "(.*?)"$/ do |text|
 end
 
 Given (/^I fill in the new charity page validly$/) do
-  stub_request_with_address("64 pinner road")
   fill_in 'organisation_address', :with => '64 pinner road'
   fill_in 'organisation_name', :with => 'Friendly charity'
 end
@@ -96,7 +95,6 @@ Given (/^I fill in the new charity page validly including the categories:$/) do 
       And I check the category "#{cat[:name]}"
     }
   end
-  stub_request_with_address("64 pinner road")
 end
 
 Given(/^I am proposing an organisation$/) do
@@ -113,7 +111,6 @@ Given (/^I fill in the proposed charity page validly$/) do
       And I check the category "#{cat}"
     }
   end
-  stub_request_with_address("64 pinner road")
 end
 
 When(/^I check the confirmation box for "(.*?)"$/) do |text|
@@ -214,7 +211,6 @@ Given /^I edit the charity email to be "(.*?)"$/ do |email|
 end
 
 When /^I edit the charity address to be "(.*?)"$/ do |address|
-  stub_request_with_address(address)
   fill_in('organisation_address', :with => address)
 end
 
@@ -355,7 +351,6 @@ Given /^I edit the charity address to be "(.*?)" when Google is indisposed$/ do 
 "results" : [],
 "status" : "OVER_QUERY_LIMIT"
 })
-  stub_request_with_address(address, body)
   fill_in('organisation_address', :with => address)
 end
 

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -5,9 +5,6 @@ Given(/^the following proposed organisations exist:$/) do |table|
     create_hash = {}
     proposer = nil
     hash.each_pair do |field_name, field_value|
-      if field_name == "address"
-        stub_request_with_address(field_value)
-      end
       if field_name != "proposer_email"
         key_value_to_add = {field_name.to_sym => field_value}
       else
@@ -35,15 +32,8 @@ Then(/^I should see the details of the proposed organisation$/) do
   end
 end
 
-Given(/^the following addresses exist:$/) do |table|
-  table.hashes.each do |addr|
-    stub_request_with_address(addr['address'])
-  end
-end
-
 Given /^the following organisations exist:$/ do |organisations_table|
   organisations_table.hashes.each do |org|
-    stub_request_with_address(org['address'])
     Organisation.create! org
   end
 end

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,1 +1,2 @@
 require 'webmock/cucumber'
+Before {stub_request(:any, /maps\.googleapis\.com/).to_rack(FakeGoogleGeocode)}


### PR DESCRIPTION
I am proposing this change because while working on a bug fix I am finding it necessary to simplify testing.

The bug's PT is https://www.pivotaltracker.com/story/show/93410464

"editing postcode does not appear to trigger geocode event"

Our current testing does not care about postcode, just the address.  By going through the Sinatra app we can make all our tests postcode aware in one place.