### PR TITLE
Make default be generated pseudorandom value for secrets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,3 @@ DEPENDENCIES
   uri-handler
   url_validator
   webmock (= 1.20.0)
-
-BUNDLED WITH
-   1.10.5

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,12 +1,13 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
+require 'securerandom'
 Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
   config.mailer_sender = "support@harrowcn.org.uk"
    
-  config.secret_key = ENV['DEVISE_SECRET_KEY'] || '2f7f19354e23c74299e72ec771ba2509ea0f65c87584fb4a4c3a344e73ec5d2482384e069f978d1a500c87d24df645c838081b9bf2c9a45b06bc374a56244fe2'
+  config.secret_key = ENV['DEVISE_SECRET_KEY'] || SecureRandom.hex(64)
   # Configure the class responsible to send e-mails.
   config.mailer = "CustomDeviseMailer"
 

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,5 +4,8 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-LocalSupport::Application.config.secret_token = ENV['MYAPP_SECRET_TOKEN'] || '98f7bafde9e9f5cab69c8e3f25a0f70bf8f97f69594f87fa3caa42e58aa0b1508f1c2efac3123a6975386fc8b9c742df9a844b0024eea553a7eb6808a4a9a02a'
-LocalSupport::Application.config.secret_key_base = ENV['MYAPP_SECRET_KEY_BASE'] || '20af600cc96db70dedfb207b9608c9ee0b0ad0dcfed270c02c870b0a6d45312821f996cc04aa43e7d0a504d6d6c3b514c07529bad3fb1e7f262f88df615b73b5'
+require 'securerandom'
+
+LocalSupport::Application.config.secret_token = ENV['MYAPP_SECRET_TOKEN'] || SecureRandom.hex(64)
+LocalSupport::Application.config.secret_key_base = ENV['MYAPP_SECRET_KEY_BASE'] || SecureRandom.hex(64)
+


### PR DESCRIPTION
It's a security risk to use a publicly known value as the default secret rails token.  A well crafted request can execute arbitrary code on a developers comp.