### PR TITLE
WIP: Bug fixes for relative urls in emails

### DIFF
--- a/app/views/admin_mailer/new_org_waiting_for_approval.html.erb
+++ b/app/views/admin_mailer/new_org_waiting_for_approval.html.erb
@@ -1,2 +1,2 @@
 A new organisation called <%= @org.name %> has been proposed for inclusion in the Harrow Community Network.
-<%= link_to "Click here to view this proposed organisation", proposed_organisation_path(@org) %>
+<%= link_to "Click here to view this proposed organisation", proposed_organisation_url(@org) %>

--- a/app/views/org_admin_mailer/new_org_admin.html.erb
+++ b/app/views/org_admin_mailer/new_org_admin.html.erb
@@ -1,2 +1,2 @@
 You have been made an organisation admin for the organisation called <%= @org.name %> on the Harrow Community Network. After logging in,
-you will be able to update your organisation's directory entry. <%= link_to "Click here to view your organisation on the Harrow Community Network.", organisation_path(@org) %>
+you will be able to update your organisation's directory entry. <%= link_to "Click here to view your organisation on the Harrow Community Network.", organisation_url(@org) %>

--- a/app/views/org_admin_mailer/notify_proposed_org_accepted.html.erb
+++ b/app/views/org_admin_mailer/notify_proposed_org_accepted.html.erb
@@ -4,7 +4,7 @@ We have granted your request to have it included in our directory.
 
 Details of your organisation are now live in our directory.
 
-<%= link_to "You can edit your organisation details by logging in and editing it directly.", organisation_path(@org)%>
+<%= link_to "You can edit your organisation details by logging in and editing it directly.", organisation_url(@org)%>
 
 
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,7 +37,8 @@ LocalSupport::Application.configure do
   # Allow pass debug_assets=true as a query parameter to load pages with unpackaged assets
   config.assets.allow_debugging = true
 
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' } 
+  config.action_mailer.default_url_options = { :host => 'localhost:3000', :port => 3000 }
+  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
   config.middleware.use RackSessionAccess::Middleware
   config.eager_load = false
 end

--- a/features/admin/admin_moderate_proposed_organisations.feature
+++ b/features/admin/admin_moderate_proposed_organisations.feature
@@ -34,6 +34,9 @@ Feature: Admin moderates an organisation to be added to HarrowCN
     And an email should be sent to "registered_user-1@example.com" as notification of the acceptance of proposed organisation "Unfriendly"
     And "registered_user-1@example.com" is an organisation admin of "Unfriendly"
     And I should see "A notification of acceptance was sent to registered_user-1@example.com"
+    And I click on the link in the email notification of acceptance of proposed organisation to "registered_user-1@example.com"
+    Then show me the page
+    Then I should be on the show page for the organisation named "Unfriendly"
 
   Scenario: Unregistered user is invited when superadmin accepts proposed organisation
     Given the following proposed organisations exist:

--- a/features/admin/admin_moderate_proposed_organisations.feature
+++ b/features/admin/admin_moderate_proposed_organisations.feature
@@ -34,9 +34,6 @@ Feature: Admin moderates an organisation to be added to HarrowCN
     And an email should be sent to "registered_user-1@example.com" as notification of the acceptance of proposed organisation "Unfriendly"
     And "registered_user-1@example.com" is an organisation admin of "Unfriendly"
     And I should see "A notification of acceptance was sent to registered_user-1@example.com"
-    And I click on the link in the email notification of acceptance of proposed organisation to "registered_user-1@example.com"
-    Then show me the page
-    Then I should be on the show page for the organisation named "Unfriendly"
 
   Scenario: Unregistered user is invited when superadmin accepts proposed organisation
     Given the following proposed organisations exist:

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -143,7 +143,7 @@ def find_emails_to email
 end
 
 def find_emails_with_accept_invitation_link emails, verbiage
-  emails.select{|email| Nokogiri::HTML(email.body.raw_source).search("//a[text()='#{verbiage}']")}
+  emails.select{|email| !Nokogiri::HTML(email.body.raw_source).search("//a[text()='#{verbiage}']").empty?}
 end
 
 def extract_invite_link email
@@ -152,13 +152,26 @@ def extract_invite_link email
 end
 
 def extract_invite_link_for_proposed_org email
-  emails_with_accept_link = find_emails_with_accept_invitation_link(find_emails_to(email), "Take over your organisation on HCN by clicking here.")
+  emails_with_accept_link = find_emails_with_accept_invitation_link(find_emails_to(email), "You can get admin access and edit your organisation details by clicking here.")
   Nokogiri::HTML(emails_with_accept_link.first.body.raw_source).search("//a[text()='You can get admin access and edit your organisation details by clicking here.']")[0].attribute("href").value
+end
+
+def find_emails_with_view_link_for_accepted_org emails, verbiage
+  emails.select{|email| !Nokogiri::HTML(email.body.raw_source).search("//a[text()='#{verbiage}']").empty?}
+end
+
+def extract_view_link_for_accepted_org email
+  emails_with_view_link = find_emails_with_view_link_for_accepted_org(find_emails_to(email),"You can edit your organisation details by logging in and editing it directly.")
+  Nokogiri::HTML(emails_with_view_link.first.body.raw_source).search("//a[text()='You can edit your organisation details by logging in and editing it directly.']")[0].attribute("href").value
 end
 
 And(/^I click on the invitation link in the proposed org accepted email to "(.*?)"$/) do |email|
   visit extract_invite_link_for_proposed_org(email)
   step "I should be on the invitation page"
+end
+
+And(/^I click on the link in the email notification of acceptance of proposed organisation to "(.*?)"$/) do |email|
+  visit extract_view_link_for_accepted_org(email)
 end
 
 Given(/^I click on the invitation link in the email to "([^\"]+)"$/) do |email|

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -170,10 +170,6 @@ And(/^I click on the invitation link in the proposed org accepted email to "(.*?
   step "I should be on the invitation page"
 end
 
-And(/^I click on the link in the email notification of acceptance of proposed organisation to "(.*?)"$/) do |email|
-  visit extract_view_link_for_accepted_org(email)
-end
-
 Given(/^I click on the invitation link in the email to "([^\"]+)"$/) do |email|
   visit extract_invite_link(email)
   step "I should be on the invitation page"

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -147,7 +147,7 @@ def find_emails_with_accept_invitation_link emails, verbiage
 end
 
 def extract_invite_link email
-  emails_with_accept_link = find_emails_with_accept_invitation_link(find_emails_to(email), 'Accept Invitation')
+  emails_with_accept_link = find_emails_with_accept_invitation_link(find_emails_to(email), 'Accept invitation')
   Nokogiri::HTML(emails_with_accept_link.first.body.raw_source).search("//a[text()='Accept invitation']")[0].attribute("href").value
 end
 

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -18,7 +18,7 @@ end
 And(/^an email should be sent to "(.*?)" as notice of becoming org admin of "(.*?)"$/) do |email, org_name|
   message = "You have been made an organisation admin for the organisation called #{org_name} on the Harrow Community Network. After logging in,
 you will be able to update your organisation's directory entry."
-  expect_email_exists(message: message, email: email, link: organisation_path(Organisation.find_by(name: org_name)), 
+  expect_email_exists(message: message, email: email, link: organisation_url(Organisation.find_by(name: org_name)),
                       link_text: "Click here to view your organisation on the Harrow Community Network.")
 end
 
@@ -29,7 +29,7 @@ end
 
 Then(/^an email should be sent to "(.*?)" as notification of the acceptance of proposed organisation "(.*?)"$/) do |email, org_name|
   message = "Thank you for registering your organisation.\n\nWe have granted your request to have it included in our directory.\n\nDetails of your organisation are now live in our directory."
-  expect_email_exists(message: message, email: email, link: organisation_path(Organisation.find_by(name: org_name)) , link_text: "You can edit your organisation details by logging in and editing it directly.")
+  expect_email_exists(message: message, email: email, link: organisation_url(Organisation.find_by(name: org_name)) , link_text: "You can edit your organisation details by logging in and editing it directly.")
 end
 
 Then(/^an invitational email should be sent to "(.*?)" as notification of the acceptance of proposed organisation "(.*?)"$/) do |email, org_name|
@@ -45,7 +45,7 @@ end
 Then(/^an email should be sent to "(.*?)" as notification of the proposed organisation$/) do |email|
   message = "A new organisation called #{proposed_org_fields[:name]} has been proposed for inclusion in the Harrow Community Network."
   expect_email_exists(message: message,email: email, 
-    link: proposed_organisation_path(ProposedOrganisation.find_by(name: proposed_org_fields[:name])),
+    link: proposed_organisation_url(ProposedOrganisation.find_by(name: proposed_org_fields[:name])),
     link_text: "Click here to view this proposed organisation"
   )
 end


### PR DESCRIPTION
Well, capybara seems happy to visit a relative url and append the default host to it.  I read that behavior depends on the driver.  Thoughts?