### PR TITLE
Refactored invite deleted user bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,6 +75,6 @@ class User < ActiveRecord::Base
   end
 
   def self.purge_deleted_users_where(query)
-    User.deleted.delete User.deleted.where(query).pluck(:id)
+    User.deleted.delete_all(query)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,4 +73,8 @@ class User < ActiveRecord::Base
     self.pending_organisation_id = organisation_id
     save!
   end
+
+  def self.purge_deleted_users_where(query)
+    User.deleted.delete User.deleted.where(query).pluck(:id)
+  end
 end

--- a/app/services/batch_invite_job.rb
+++ b/app/services/batch_invite_job.rb
@@ -7,7 +7,7 @@ class BatchInviteJob
 
   def run
     tell_devise_if_okay_to_resend_invitations
-    complitely_delete_deleted_users
+    purge_deleted_users
     invite_users_and_collate_results
   end
 
@@ -39,8 +39,8 @@ class BatchInviteJob
     end
   end
 
-  def complitely_delete_deleted_users
-    User.deleted.delete User.deleted.where(email: @invites.flat_map{|org_id, email| email.downcase}).pluck(:id)
+  def purge_deleted_users
+    User.purge_deleted_users_where(email: @invites.flat_map{|org_id, email| email.downcase})
 
   end
 end

--- a/app/services/batch_invite_job.rb
+++ b/app/services/batch_invite_job.rb
@@ -7,6 +7,7 @@ class BatchInviteJob
 
   def run
     tell_devise_if_okay_to_resend_invitations
+    complitely_delete_deleted_users
     invite_users_and_collate_results
   end
 
@@ -36,5 +37,10 @@ class BatchInviteJob
     else
       'Invited!'
     end
+  end
+
+  def complitely_delete_deleted_users
+    User.deleted.delete User.deleted.where(email: @invites.flat_map{|org_id, email| email.downcase}).pluck(:id)
+
   end
 end

--- a/app/services/batch_invite_job.rb
+++ b/app/services/batch_invite_job.rb
@@ -40,7 +40,6 @@ class BatchInviteJob
   end
 
   def purge_deleted_users
-    User.purge_deleted_users_where(email: @invites.flat_map{|org_id, email| email.downcase})
-
+    User.purge_deleted_users_where(email: @invites.flat_map{ |org_id, email| email.downcase })
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -79,6 +79,9 @@ FactoryGirl.define do
         user.save!
       end
     end
+    factory :deleted_user do
+      deleted_at 1.year.ago
+    end
   end
 
   factory :volunteer_op do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -283,7 +283,7 @@ describe User, :type => :model do
   end
 
   describe '.purge_deleted_users_where' do
-    subject(:do_purge) {User.purge_deleted_users_where(email: 'yes@hello.com')}
+    subject(:do_purge) { User.purge_deleted_users_where(email: 'yes@hello.com') }
     it 'purge deleted user when user match query' do
       user = FactoryGirl.create :deleted_user, email: 'yes@hello.com'
       expect { do_purge }.to change(User.deleted, :count).by(-1)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -282,6 +282,19 @@ describe User, :type => :model do
     end
   end
 
-
-
+  describe '.purge_deleted_users_where' do
+    subject{User.purge_deleted_users_where(email: 'yes@hello.com')}
+    it 'purge deleted user when user match query' do
+      user = FactoryGirl.create :deleted_user, email: 'yes@hello.com'
+      expect{subject}.to change(User.deleted, :count).by(-1)
+    end
+    it 'does not delete users that is not match query' do
+      user = FactoryGirl.create :deleted_user, email: 'no@hello.com'
+      expect{subject}.to change(User.deleted, :count).by(0)
+    end
+    it 'does not affect undeleted users' do
+      user = FactoryGirl.create :user, email: 'yes@hello.com'
+      expect{subject}.to change(User, :count).by(0)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -283,18 +283,18 @@ describe User, :type => :model do
   end
 
   describe '.purge_deleted_users_where' do
-    subject{User.purge_deleted_users_where(email: 'yes@hello.com')}
+    subject(:do_purge) {User.purge_deleted_users_where(email: 'yes@hello.com')}
     it 'purge deleted user when user match query' do
       user = FactoryGirl.create :deleted_user, email: 'yes@hello.com'
-      expect{subject}.to change(User.deleted, :count).by(-1)
+      expect { do_purge }.to change(User.deleted, :count).by(-1)
     end
     it 'does not delete users that is not match query' do
       user = FactoryGirl.create :deleted_user, email: 'no@hello.com'
-      expect{subject}.to change(User.deleted, :count).by(0)
+      expect { do_purge }.to change(User.deleted, :count).by(0)
     end
     it 'does not affect undeleted users' do
       user = FactoryGirl.create :user, email: 'yes@hello.com'
-      expect{subject}.to change(User, :count).by(0)
+      expect { do_purge }.to change(User, :count).by(0)
     end
   end
 end

--- a/spec/services/batch_invite_job_spec.rb
+++ b/spec/services/batch_invite_job_spec.rb
@@ -59,7 +59,6 @@ describe ::BatchInviteJob do
     it 'resend invitations to a deleted user' do
       deleted_user = FactoryGirl.create(:deleted_user, email: 'YES@hello.com')
       valid_user = instance_double('User', errors: [])
-      invalid_user = instance_double('User', errors: ['email has been taken'])
       expect(User).to receive(:purge_deleted_users_where).with(email: ['yes@hello.com', 'yes@hello.com'])
       allow(User).to receive(:invite!).and_return(valid_user)
       subject

--- a/spec/services/batch_invite_job_spec.rb
+++ b/spec/services/batch_invite_job_spec.rb
@@ -50,12 +50,6 @@ describe ::BatchInviteJob do
       )
     end
 
-
-   xit 'resend invitation to a deleted user (not isolated)' do
-     deleted_user = FactoryGirl.create(:user, email: 'YES@hello.com', deleted_at: "2015-11-11 08:37:14")
-     expect(-> { subject }).to change(User, :count).by(1)
-   end
-
     it 'resend invitations to a deleted user' do
       deleted_user = FactoryGirl.create(:deleted_user, email: 'YES@hello.com')
       valid_user = instance_double('User', errors: [])
@@ -63,7 +57,6 @@ describe ::BatchInviteJob do
       allow(User).to receive(:invite!).and_return(valid_user)
       subject
     end
-
   end
 
   context 'failure' do

--- a/spec/services/batch_invite_job_spec.rb
+++ b/spec/services/batch_invite_job_spec.rb
@@ -13,28 +13,28 @@ describe ::BatchInviteJob do
     current_user # lazy-loading messes up DB counts
   end
 
-  subject { BatchInviteJob.new(params, current_user).run }
+  subject(:do_batch_invite) { BatchInviteJob.new(params, current_user).run }
 
   context 'success' do
     let(:user) { User.find_by_email org.email.downcase }
 
     it 'a new user is persisted' do
-      expect(-> { subject }).to change(User, :count).by(1)
+      expect { do_batch_invite }.to change(User, :count).by(1)
     end
 
     it 'warning: email may be mutated' do
-      subject
+      do_batch_invite
       expect(user.email).to_not eq org.email
       expect(user.email).to eq org.email.downcase
     end
 
     it 'associations can be set' do
-      subject
+      do_batch_invite
       expect(user.organisation_id).to eq org.id
     end
 
     it 'sends a custom email' do
-      subject
+      do_batch_invite
       email = ActionMailer::Base.deliveries.last
       expect(email.from).to eq ['support@harrowcn.org.uk']
       expect(email.reply_to).to eq ['support@harrowcn.org.uk']
@@ -44,7 +44,7 @@ describe ::BatchInviteJob do
     end
 
     it 'example response for invites with duplicates' do
-      expect(subject).to eq(
+      expect(do_batch_invite).to eq(
         {org.id => 'Invited!',
          (org.id+1) => 'Error: Email has already been taken'}
       )
@@ -55,7 +55,7 @@ describe ::BatchInviteJob do
       valid_user = instance_double('User', errors: [])
       expect(User).to receive(:purge_deleted_users_where).with(email: ['yes@hello.com', 'yes@hello.com'])
       allow(User).to receive(:invite!).and_return(valid_user)
-      subject
+      do_batch_invite
     end
   end
 

--- a/spec/services/batch_invite_job_spec.rb
+++ b/spec/services/batch_invite_job_spec.rb
@@ -49,6 +49,13 @@ describe ::BatchInviteJob do
          (org.id+1) => 'Error: Email has already been taken'}
       )
     end
+
+
+    it 'resend invitation to a deleted user' do
+      deleted_user = FactoryGirl.create(:user,email: 'YES@hello.com', deleted_at: "2015-11-11 08:37:14")
+      expect(-> { subject }).to change(User, :count).by(1)
+    end
+
   end
 
   context 'failure' do

--- a/spec/services/batch_invite_job_spec.rb
+++ b/spec/services/batch_invite_job_spec.rb
@@ -51,9 +51,18 @@ describe ::BatchInviteJob do
     end
 
 
-    it 'resend invitation to a deleted user' do
-      deleted_user = FactoryGirl.create(:user,email: 'YES@hello.com', deleted_at: "2015-11-11 08:37:14")
-      expect(-> { subject }).to change(User, :count).by(1)
+   xit 'resend invitation to a deleted user (not isolated)' do
+     deleted_user = FactoryGirl.create(:user, email: 'YES@hello.com', deleted_at: "2015-11-11 08:37:14")
+     expect(-> { subject }).to change(User, :count).by(1)
+   end
+
+    it 'resend invitations to a deleted user' do
+      deleted_user = FactoryGirl.create(:deleted_user, email: 'YES@hello.com')
+      valid_user = instance_double('User', errors: [])
+      invalid_user = instance_double('User', errors: ['email has been taken'])
+      expect(User).to receive(:purge_deleted_users_where).with(email: ['yes@hello.com', 'yes@hello.com'])
+      allow(User).to receive(:invite!).and_return(valid_user)
+      subject
     end
 
   end


### PR DESCRIPTION
I tried to do some refactoring of code and tests:  
1. Moved responsibiliity to purge deleted users from batch_invite_job#purge_deleted_users  to User.purge_deleted_users_where(query) model and cover it with tests (I'm not sure about tests, maybe they need mocks or using simple User models rather than FactoryGirl)
2. Refactored test in batch_invite_job to isolate it from database and User model.
3. I think that batch_invite_job#result_of_inviting  also should be moved to another class, probably to User. 