### PR TITLE
Search feature on each organization page (Jongmin & Yana)

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -36,6 +36,7 @@ class OrganisationsController < BaseOrganisationsController
     @grabbable = current_user ? current_user.can_request_org_admin?(@organisation) : true
     @can_propose_edits = current_user.present? && !@editable
     @markers = build_map_markers(organisations)
+    @cat_name_ids = Category.name_and_id_for_what_who_and_how
   end
 
   # GET /organisations/new
@@ -81,7 +82,7 @@ class OrganisationsController < BaseOrganisationsController
   def update
     @organisation = Organisation.find(params[:id])
     params[:organisation][:superadmin_email_to_add] = params[:organisation_superadmin_email_to_add] if params[:organisation]
-    update_params = OrganisationParams.build params 
+    update_params = OrganisationParams.build params
     return false unless user_can_edit? @organisation
     if @organisation.update_attributes_with_superadmin(update_params)
       redirect_to @organisation, notice: 'Organisation was successfully updated.'

--- a/app/views/organisations/_search_form.html.erb
+++ b/app/views/organisations/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag("/organisations/search", :id => "organisation_search", :method => "get") do %>
+<%= form_tag(organisations_search_path, :id => "organisation_search", :method => "get") do %>
   <div class="flex-column">
     <div class="flex-row">
       <div class="left-side">

--- a/app/views/organisations/_search_form.html.erb
+++ b/app/views/organisations/_search_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_tag("/organisations/search", :id => "organisation_search", :method => "get") do %>
+  <div class="flex-column">
+    <div class="flex-row">
+      <div class="left-side">
+        <%= label_tag(:what_id, "What They Do", class: 'field-label') %>
+      </div>
+      <div class="right-side">
+        <%= select_tag(:what_id, options_for_select(@cat_name_ids[:what], @parsed_params.try(:what_id)), { :include_blank => 'All' }) %>
+      </div>
+    </div>
+    <div class="flex-row">
+      <div class="left-side">
+        <%= label_tag(:who_id, "Who They Help", class: 'field-label') %>
+      </div>
+      <div class="right-side">
+        <%= select_tag(:who_id, options_for_select(@cat_name_ids[:who], @parsed_params.try(:who_id)), :include_blank => 'All' ) %>
+      </div>
+    </div>
+    <div class="flex-row">
+      <div class="left-side">
+        <%= label_tag(:how_id, "How They Help", class: 'field-label') %>
+      </div>
+      <div class="right-side">
+        <%= select_tag(:how_id, options_for_select(@cat_name_ids[:how], @parsed_params.try(:how_id)), { :include_blank => 'All' }) %>
+      </div>
+    </div>
+    <div class="flex-row">
+      <div class="left-side">
+        <%= label_tag(:q, "Optional Search Text", class: 'field-label') %>
+      </div>
+      <div class="right-side">
+        <%= text_field_tag(:q, @parsed_params.try(:query_term)) %>
+        <%= submit_tag "Submit", { :class => 'btn btn-info' } %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,40 +1,4 @@
-<%= form_tag("/organisations/search", :id => "organisation_search", :method => "get") do %>
-  <div class="flex-column">
-    <div class="flex-row">
-      <div class="left-side">
-        <%= label_tag(:what_id, "What They Do", class: 'field-label') %>
-      </div>
-      <div class="right-side">
-        <%= select_tag(:what_id, options_for_select(@cat_name_ids[:what], @parsed_params.try(:what_id)), { :include_blank => 'All' }) %>
-      </div>
-    </div>
-    <div class="flex-row">
-      <div class="left-side">
-        <%= label_tag(:who_id, "Who They Help", class: 'field-label') %>
-      </div>
-      <div class="right-side">
-        <%= select_tag(:who_id, options_for_select(@cat_name_ids[:who], @parsed_params.try(:who_id)), :include_blank => 'All' ) %>
-      </div>
-    </div>
-    <div class="flex-row">
-      <div class="left-side">
-        <%= label_tag(:how_id, "How They Help", class: 'field-label') %>
-      </div>
-      <div class="right-side">
-        <%= select_tag(:how_id, options_for_select(@cat_name_ids[:how], @parsed_params.try(:how_id)), { :include_blank => 'All' }) %>
-      </div>
-    </div>
-    <div class="flex-row">
-      <div class="left-side">
-        <%= label_tag(:q, "Optional Search Text", class: 'field-label') %>
-      </div>
-      <div class="right-side">
-        <%= text_field_tag(:q, @parsed_params.try(:query_term)) %>
-        <%= submit_tag "Submit", { :class => 'btn btn-info' } %>
-      </div>
-    </div>
-  </div>
-<% end %>
+<%= render partial: 'search_form' %>
 
 <div id="orgs_scroll">
   <div class="table">
@@ -59,5 +23,3 @@
 <% render partial: 'shared/map_scripts', locals: {markers: @markers} %>
 
 <% render 'shared/map_legend_script' %>
-
-

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -2,7 +2,9 @@
     <%= javascript_include_tag 'this_is_my_org' %>
 <% end %>
 
-<%= render partial: "search_form" %>
+<% if feature_active? :search_input_bar %>
+  <%= render partial: "search_form" %>
+<% end %>
 <%= render partial: "show", locals: {org: @organisation} %>
 <div id="org-cat-buttons" class="row">
   <div class="position-bottom span6">

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -2,7 +2,7 @@
     <%= javascript_include_tag 'this_is_my_org' %>
 <% end %>
 
-<% if feature_active? :search_input_bar %>
+<% if feature_active? :search_input_bar_on_org_pages %>
   <%= render partial: "search_form" %>
 <% end %>
 <%= render partial: "show", locals: {org: @organisation} %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -2,6 +2,7 @@
     <%= javascript_include_tag 'this_is_my_org' %>
 <% end %>
 
+<%= render partial: "search_form" %>
 <%= render partial: "show", locals: {org: @organisation} %>
 <div id="org-cat-buttons" class="row">
   <div class="position-bottom span6">

--- a/db/migrate/20151209125200_add_search_input_bar_on_org_pages.rb
+++ b/db/migrate/20151209125200_add_search_input_bar_on_org_pages.rb
@@ -1,0 +1,9 @@
+class AddSearchInputBarOnOrgPages < ActiveRecord::Migration
+  def up
+    Feature.create(name: :search_input_bar_on_org_pages)
+  end
+
+  def down
+    Feature.find_by(name: :search_input_bar_on_org_pages).destroy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150627195630) do
+ActiveRecord::Schema.define(version: 20151209125200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/features/admin/admin_new_charity.feature
+++ b/features/admin/admin_new_charity.feature
@@ -23,7 +23,7 @@ Feature: Super Admin creating charity
       | Education         | 303                   |
       | Give them things  | 304                   |
       | Teach them things | 305                   |
- 
+
     And cookies are approved
 
   Scenario: Unsuccessfully attempt to create charity without being signed-in
@@ -58,7 +58,7 @@ Feature: Super Admin creating charity
     Then I should see "Organisation was successfully created."
     And I should see "Feed the hungry"
     And I should see "Accommodation"
-    And I should not see "General"
+    And I should not see "General" within "org-categories"
 
   Scenario: Non-superadmin unsuccessfully attempts to create an organisation
     Given I am signed in as a non-superadmin

--- a/features/individual_charity_pages/charity_page.feature
+++ b/features/individual_charity_pages/charity_page.feature
@@ -53,11 +53,11 @@ Feature: Web page owned by each charity
     And I should see "Education" within "what_they_do"
     And I should see "Voluntary" within "who_they_help"
     And I should see "Finance" within "how_they_help"
-    And I should not see "Animal Welfare"
+    And I should not see "Animal Welfare" within "what_they_do"
     And I visit the show page for the organisation named "Unfriendly"
-    Then I should not see "Health"
-    And I should not see "Education"
-    And I should not see "Animal Welfare"
+    Then I should not see "Health" within "what_they_do"
+    And I should not see "Education" within "what_they_do"
+    And I should not see "Animal Welfare" within "what_they_do"
 
   Scenario Outline: show labels if field is present
     Then I should see "<label>"

--- a/features/individual_charity_pages/charity_page.feature
+++ b/features/individual_charity_pages/charity_page.feature
@@ -13,7 +13,7 @@ Feature: Web page owned by each charity
       | email                         | password | organisation | confirmed_at         |
       | registered_user-1@example.com | pppppppp | Friendly     | 2007-01-01  10:00:00 |
       | registered_user-2@example.com | pppppppp |              | 2007-01-01  10:00:00 |
-
+    And that the search_input_bar flag is enabled
     And I visit the show page for the organisation named "Friendly"
 
     Given the following categories exist:

--- a/features/individual_charity_pages/charity_page.feature
+++ b/features/individual_charity_pages/charity_page.feature
@@ -23,14 +23,21 @@ Feature: Web page owned by each charity
       | Education         | 103                   |
       | Voluntary         | 201                   |
       | Finance           | 301                   |
+      | Advocacy          | 303                   |
      Given the following categories_organisations exist:
-      | category  | organisation |
-      | Health    | Friendly |
-      | Education | Friendly |
-      | Voluntary | Friendly  |
-      | Finance   | Friendly  |
+      | category        | organisation |
+      | Health          | Friendly     |
+      | Education       | Friendly     |
+      | Voluntary       | Friendly     |
+      | Finance         | Friendly     |
+      | Advocacy        | Unfriendly   |
     And I visit the show page for the organisation named "Friendly"
 
+  Scenario: Search for organisations on an organization individual page
+    Given I select the "Advocacy" category from How They Help
+    And I press "Submit"
+    Then I should see "Unfriendly"
+    And I should not see "Friendly"
 
   Scenario: be able to view link to charity site on individual charity page
     Then I should see the external website link for "Friendly" charity

--- a/features/individual_charity_pages/charity_page.feature
+++ b/features/individual_charity_pages/charity_page.feature
@@ -13,7 +13,7 @@ Feature: Web page owned by each charity
       | email                         | password | organisation | confirmed_at         |
       | registered_user-1@example.com | pppppppp | Friendly     | 2007-01-01  10:00:00 |
       | registered_user-2@example.com | pppppppp |              | 2007-01-01  10:00:00 |
-    And that the search_input_bar flag is enabled
+    And that the search_input_bar_on_org_pages flag is enabled
     And I visit the show page for the organisation named "Friendly"
 
     Given the following categories exist:

--- a/features/individual_charity_pages/edit_own_charity_profile.feature
+++ b/features/individual_charity_pages/edit_own_charity_profile.feature
@@ -153,11 +153,11 @@ Scenario Outline: Successfully add and remove an organisation's categories
   Then I <action1> the category "<category1>"
   And I <action2> the category "<category2>"
   And I press "Update Organisation"
-  Then I should <visibility1> "<category1>"
-  And I should <visibility2> "<category2>"
+  Then I should <visibility1> "<category1>" within "org-categories"
+  And I should <visibility2> "<category2>" within "org-categories"
   Examples:
   | category1      | action1    | visibility1 | category2            | action2 | visibility2 |
   | Health         | uncheck    | not see     | Child welfare        | check   | see         |
   | Animal welfare | check      | see         | Education            | uncheck | not see     |
   | Health         | uncheck    | not see     | Education            | uncheck | not see     |
-  | General        | check      | see         | Give them things     | check   | see         |
+  | General        | check      | see         | Give them things     | check   | see         | 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -328,6 +328,10 @@ Then(/^I should see "(.*?)" within "(.*?)"$/) do |text, selector|
   within('#' + selector) { expect(page).to have_content text}
 end
 
+Then(/^I should not see "(.*?)" within "(.*?)"$/) do |text, selector|
+  within('#' + selector) { expect(page).not_to have_content text}
+end
+
 Then(/^I should see the following:$/) do |table|
   table.rows.each do |text|
     expect(page).to have_content text.first

--- a/spec/views/organisations/show.html.erb_spec.rb
+++ b/spec/views/organisations/show.html.erb_spec.rb
@@ -194,7 +194,7 @@ describe 'organisations/show.html.erb', :type => :view do
 
   describe 'create volunteer opportunity button' do
     it 'shows when belongs_to is true' do
-      allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(false)
+      allow(view).to receive(:feature_active?).with(:search_input_bar_on_org_pages).and_return(false)
       allow(view).to receive(:feature_active?).with(:volunteer_ops_create).and_return(true)
       assign(:can_create_volunteer_op, true)
       render
@@ -208,7 +208,7 @@ describe 'organisations/show.html.erb', :type => :view do
     end
 
     it 'is shown when feature is active' do
-      allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(false)
+      allow(view).to receive(:feature_active?).with(:search_input_bar_on_org_pages).and_return(false)
       assign(:can_create_volunteer_op, true)
       expect(view).to receive(:feature_active?).
         with(:volunteer_ops_create).and_return(true)
@@ -218,7 +218,7 @@ describe 'organisations/show.html.erb', :type => :view do
     end
 
     it 'is not visible when feature is inactive' do
-      allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(false)
+      allow(view).to receive(:feature_active?).with(:search_input_bar_on_org_pages).and_return(false)
       assign(:can_create_volunteer_op, true)
       expect(view).to receive(:feature_active?).
         with(:volunteer_ops_create).and_return(false)
@@ -232,7 +232,7 @@ describe 'organisations/show.html.erb', :type => :view do
   describe 'show search input bar' do
     context 'feature is on' do
       it 'displays search feature' do
-        allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(true)
+        allow(view).to receive(:feature_active?).with(:search_input_bar_on_org_pages).and_return(true)
         render
         expect(rendered).to have_selector "form input[name='q']"
         expect(rendered).to have_selector "form input[type='submit']"
@@ -246,7 +246,7 @@ describe 'organisations/show.html.erb', :type => :view do
 
     context 'feature is off' do
       it 'does not show search feature' do
-        allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(false)
+        allow(view).to receive(:feature_active?).with(:search_input_bar_on_org_pages).and_return(false)
         render
         expect(rendered).not_to have_selector "form input[name='q']"
         expect(rendered).not_to have_selector "form input[type='submit']"

--- a/spec/views/organisations/show.html.erb_spec.rb
+++ b/spec/views/organisations/show.html.erb_spec.rb
@@ -17,7 +17,22 @@ describe 'organisations/show.html.erb', :type => :view do
     }
   end
 
-  before(:each) { assign(:organisation, organisation) }
+  before(:each) do
+    assign(:organisation, organisation)
+    assign(:parsed_params, double("ParsedParams", :query_term => 'search'))
+    assign(:cat_name_ids, {what: [], who: [], how: []})
+  end
+
+  it "renders a search form" do
+    render
+    expect(rendered).to have_selector "form input[name='q']"
+    expect(rendered).to have_selector "form input[type='submit']"
+    expect(rendered).to have_selector "form input[value='search']"
+    expect(rendered).to have_content "Optional Search Text"
+    expect(rendered).to have_selector "form select[name='what_id']"
+    expect(rendered).to have_selector "form select[name='who_id']"
+    expect(rendered).to have_selector "form select[name='how_id']"
+  end
 
   context 'page styling' do
     it 'name should be wrapped in h2 tag' do
@@ -30,10 +45,10 @@ describe 'organisations/show.html.erb', :type => :view do
       expect(rendered).to have_content('Email: ')
       expect(rendered).to have_css("a[href='mailto:#{organisation.email}']")
       expect(rendered).to have_content('Website: ')
-      expect(rendered).to have_link "#{organisation.website}", :href => organisation.website      
+      expect(rendered).to have_link "#{organisation.website}", :href => organisation.website
       expect(rendered).to have_xpath("//a[@href='#{organisation.website}'][@target='_blank']")
       expect(rendered).to have_content('Donation Info: ')
-      expect(rendered).to have_link "Donate to #{organisation.name} now!", :href => organisation.donation_info 
+      expect(rendered).to have_link "Donate to #{organisation.name} now!", :href => organisation.donation_info
       expect(rendered).to have_xpath("//a[@href='#{organisation.donation_info}'][@target = '_blank']")
     end
     it 'ABSENT: postcode, email, website, donation info' do
@@ -119,7 +134,7 @@ describe 'organisations/show.html.erb', :type => :view do
     render
     expect(rendered).to have_content organisation.address
   end
-  
+
   it 'renders the actual phone if publish phone is true' do
     organisation.publish_phone = true
     render
@@ -131,12 +146,12 @@ describe 'organisations/show.html.erb', :type => :view do
     render
     expect(rendered).not_to have_content organisation.email
   end
-  
+
   context 'edit button' do
     it 'renders edit button if editable true' do
       assign(:editable, true)
       render
-      expect(rendered).to have_link 'Edit', :href => edit_organisation_path(organisation.id)   
+      expect(rendered).to have_link 'Edit', :href => edit_organisation_path(organisation.id)
     end
     it 'does not render edit button if editable false' do
       assign(:editable, false)
@@ -208,7 +223,7 @@ describe 'organisations/show.html.erb', :type => :view do
         with(:volunteer_ops_create).and_return(true)
       render
       expect(rendered).to have_link \
-        'Create a Volunteer Opportunity', :href => new_organisation_volunteer_op_path(organisation)      
+        'Create a Volunteer Opportunity', :href => new_organisation_volunteer_op_path(organisation)
     end
 
     it 'is not visible when feature is inactive' do

--- a/spec/views/organisations/show.html.erb_spec.rb
+++ b/spec/views/organisations/show.html.erb_spec.rb
@@ -23,17 +23,6 @@ describe 'organisations/show.html.erb', :type => :view do
     assign(:cat_name_ids, {what: [], who: [], how: []})
   end
 
-  it "renders a search form" do
-    render
-    expect(rendered).to have_selector "form input[name='q']"
-    expect(rendered).to have_selector "form input[type='submit']"
-    expect(rendered).to have_selector "form input[value='search']"
-    expect(rendered).to have_content "Optional Search Text"
-    expect(rendered).to have_selector "form select[name='what_id']"
-    expect(rendered).to have_selector "form select[name='who_id']"
-    expect(rendered).to have_selector "form select[name='how_id']"
-  end
-
   context 'page styling' do
     it 'name should be wrapped in h2 tag' do
       render
@@ -205,6 +194,7 @@ describe 'organisations/show.html.erb', :type => :view do
 
   describe 'create volunteer opportunity button' do
     it 'shows when belongs_to is true' do
+      allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(false)
       allow(view).to receive(:feature_active?).with(:volunteer_ops_create).and_return(true)
       assign(:can_create_volunteer_op, true)
       render
@@ -218,6 +208,7 @@ describe 'organisations/show.html.erb', :type => :view do
     end
 
     it 'is shown when feature is active' do
+      allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(false)
       assign(:can_create_volunteer_op, true)
       expect(view).to receive(:feature_active?).
         with(:volunteer_ops_create).and_return(true)
@@ -227,6 +218,7 @@ describe 'organisations/show.html.erb', :type => :view do
     end
 
     it 'is not visible when feature is inactive' do
+      allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(false)
       assign(:can_create_volunteer_op, true)
       expect(view).to receive(:feature_active?).
         with(:volunteer_ops_create).and_return(false)
@@ -235,6 +227,36 @@ describe 'organisations/show.html.erb', :type => :view do
         'Create a Volunteer Opportunity', :href => new_organisation_volunteer_op_path(organisation)
     end
 
+  end
+
+  describe 'show search input bar' do
+    context 'feature is on' do
+      it 'displays search feature' do
+        allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(true)
+        render
+        expect(rendered).to have_selector "form input[name='q']"
+        expect(rendered).to have_selector "form input[type='submit']"
+        expect(rendered).to have_selector "form input[value='search']"
+        expect(rendered).to have_content "Optional Search Text"
+        expect(rendered).to have_selector "form select[name='what_id']"
+        expect(rendered).to have_selector "form select[name='who_id']"
+        expect(rendered).to have_selector "form select[name='how_id']"
+      end
+    end
+
+    context 'feature is off' do
+      it 'does not show search feature' do
+        allow(view).to receive(:feature_active?).with(:search_input_bar).and_return(false)
+        render
+        expect(rendered).not_to have_selector "form input[name='q']"
+        expect(rendered).not_to have_selector "form input[type='submit']"
+        expect(rendered).not_to have_selector "form input[value='search']"
+        expect(rendered).not_to have_content "Optional Search Text"
+        expect(rendered).not_to have_selector "form select[name='what_id']"
+        expect(rendered).not_to have_selector "form select[name='who_id']"
+        expect(rendered).not_to have_selector "form select[name='how_id']"
+      end
+    end
   end
 
   describe 'show categories' do


### PR DESCRIPTION
As @tansaku suggested (#205), I tried to send this pull request from my feature branch. Maybe I should have sent it to the search_feature branch in AgileVentures. Also, I added a feature flag for search feature on each organization page. 

To activate the search feature on each organization page, you need to add it to the database in your rails console (or your Heroku or ninefold console):
```
$ Feature.create(:name => :search_input_bar)
```
When you add it, it remains off by default. To turn it on, run:
```
$ Feature.activate(:search_input_bar)
```
Then you can see the search feature on each organization page like below. 

![screen shot 2015-12-09 at 1 07 24 pm](https://cloud.githubusercontent.com/assets/12749363/11676485/ef115a22-9e75-11e5-898d-5045ddd581ef.png)

If you want to remove the feature, run: 
```
$ Feature.deactivate(:search_input_bar)
```
![screen shot 2015-12-09 at 1 14 02 pm](https://cloud.githubusercontent.com/assets/12749363/11676566/cefdf9ec-9e76-11e5-8203-a21c6dba1d81.png)