### PR TITLE
Admin Tab - rename admin tab options

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -87,12 +87,12 @@
                           <li class="dropdown" id="menuSuperAdmin">
                             <a class="dropdown-toggle" href="#" data-toggle="dropdown">Admin</a>
                             <ul class="dropdown-menu" >
-                              <li><%= link_to 'Organisations Without Users', organisations_report_path %></li>
-                              <li><%= link_to 'All Users', users_report_path %></li>
+                              <li><%= link_to 'Invite Users to become admin of Organisations', organisations_report_path %></li>
+                              <li><%= link_to 'Registered Users', users_report_path %></li>
                               <li><%= link_to 'Invited Users', invited_users_report_path %></li>
                               <li><%= link_to 'Deleted Users', deleted_users_report_path %></li>
-                              <li><%= link_to 'All Proposed Edits', proposed_organisation_edits_path %></li>
-                              <li><%= link_to 'All Proposed Organisations', proposed_organisations_path %></li>
+                              <li><%= link_to 'Pending Proposed Edits', proposed_organisation_edits_path %></li>
+                              <li><%= link_to 'Pending Proposed Organisations', proposed_organisations_path %></li>
                             </ul>
                           </li>
                       <% end %>

--- a/features/admin/admin_moderate_proposed_organisation_edits.feature
+++ b/features/admin/admin_moderate_proposed_organisation_edits.feature
@@ -17,18 +17,18 @@ Feature: Members of HCN may propose edits to organisations
       |original_name | editor_email                  | name       | description             | address        | postcode | telephone | website               | email                    | donation_info        | archived|
       |Friendly      | registered_user-2@example.com | Unfriendly | Mourning loved ones     | 30 pinner road | HA1 4HZ  | 520800000 | http://unfriendly.org | superadmin@unfriendly.xx | www.pleasedonate.com | false   |
       |Friendly      | registered_user-2@example.com | Unfriendly | Mourning loved ones     | 30 pinner road | HA1 4HZ  | 520800000 | http://unfriendly.org | superadmin@unfriendly.xx | www.pleasedonate.com | true    |
- 
+
     And cookies are approved
 
-  Scenario: Nonsuperadmins do not see all proposed edits link
+  Scenario: Nonsuperadmins do not see pending proposed edits link
     Given I am signed in as an non-superadmin
     And I visit the home page
-    Then I should not see the all proposed edits link
+    Then I should not see the pending proposed edits link
 
   Scenario: Moderate a proposed edit
     Given I am signed in as a superadmin
     And I visit the home page
-    And I click on the all proposed edits link
+    And I click on the pending proposed edits link
     And I should not see links for archived edits
     And I click on view details for the proposed edit for the organisation named "Friendly"
     And I should see a link or button "Accept Edit"

--- a/features/admin/admin_moderate_proposed_organisations.feature
+++ b/features/admin/admin_moderate_proposed_organisations.feature
@@ -70,7 +70,7 @@ Feature: Admin moderates an organisation to be added to HarrowCN
       |registered_user-2@example.com | Unfriendly | Mourning loved ones     | 30 pinner road | HA1 4HZ  | 520800000 | http://unfriendly.org | superadmin@unfriendly.xx | www.pleasedonate.com | true       |
       |registered_user-3@example.com | Friendly   | Bereavement             | 30 pinner road | HA1 4HZ  | 520800000 | http://friendly.org   | superadmin@friendly.xx   | www.pleasedonate.com | true       |
     And I visit the home page
-    And I click on the all proposed organisations link
+    And I click on the pending proposed organisations link
     Then I should see a view details link for each of the proposed organisations
 
   Scenario: Superadmin views details of proposed organisations

--- a/features/admin/navbar.feature
+++ b/features/admin/navbar.feature
@@ -17,10 +17,10 @@ Feature: Super Admin user interface
   Scenario Outline: Top navbar has a SuperAdmin dropdown menu
     Then the SuperAdmin menu has a valid <link> link
   Examples:
-    | link                        |
-    | Organisations Without Users |
-    | Invited Users               |
-    | All Users                   |
+    | link                                          |
+    | Invite Users to become admin of Organisations |
+    | Invited Users                                 |
+    | Registered Users                              |
 
   Scenario:  Highlighted button for Organisations or Volunteers
     Given I visit the organisations index page

--- a/features/admin/organisation_reports/without_users.feature
+++ b/features/admin/organisation_reports/without_users.feature
@@ -23,7 +23,7 @@ Feature: Orphans UI
   Scenario: Super Admin can invite users but only for unique emails
     Given cookies are approved
     Given I am signed in as a superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     And I check the box for "The Organisation"
     And I check the box for "The Same Email Org"
     When I click id "invite_users"
@@ -33,14 +33,14 @@ Feature: Orphans UI
   Scenario: Already invited organisations don't appear
     Given cookies are approved
     And I am signed in as a superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     Then I should not see "Yet Another Org"
 
   @javascript
   Scenario: Super Admin should be notified when email is invalid
     Given cookies are approved
     Given I am signed in as a superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     And I check the box for "Crazy Email Org"
     When I click id "invite_users"
     Then I should see "Error: Email is invalid" in the response field for "Crazy Email Org"
@@ -48,7 +48,7 @@ Feature: Orphans UI
   Scenario: As a non-superadmin trying to access orphans index
     Given cookies are approved
     Given I am signed in as a non-superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     Then I should be on the home page
     And I should see "You must be signed in as a superadmin to perform this action!"
 
@@ -57,7 +57,7 @@ Feature: Orphans UI
   Scenario: Table columns should be sortable
     Given cookies are approved
     Given I am signed in as a superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     And I click tableheader "Name"
     Then I should see "Crazy Email Org" before "The Organisation"
     When I click tableheader "Name"
@@ -67,7 +67,7 @@ Feature: Orphans UI
   Scenario: Select All button toggles all checkboxes
     Given cookies are approved
     Given I am signed in as a superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     And I press "Select All"
     Then all the checkboxes should be checked
     When I press "Select All"
@@ -88,8 +88,8 @@ Feature: Orphans UI
   Scenario: Invited user email is out of date
     Given cookies are approved
     And I am signed in as a superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     Then I should not see "Yet Another Org"
     When I edit the charity email of "Yet Another Org" to be "other_email@charity.com"
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     Then I should see "Yet Another Org"

--- a/features/admin/user_reports/admin_approve_charity_admin.feature
+++ b/features/admin/user_reports/admin_approve_charity_admin.feature
@@ -64,7 +64,7 @@ Feature: All Users Page
 
   Scenario Outline: As a superadmin I should be able to see status of all users
     Given I am signed in as a superadmin
-    And I visit the all users page
+    And I visit the registered users page
     Then I should see "<email>"
     Examples:
       | email              |
@@ -74,7 +74,6 @@ Feature: All Users Page
 
   Scenario: As a non-superadmin trying to access users index
     Given I am signed in as a non-superadmin
-    And I visit the all users page
+    And I visit the registered users page
     Then I should be on the home page
     And I should see "You must be signed in as a superadmin to perform this action!"
-

--- a/features/admin/user_reports/fix_associations.feature
+++ b/features/admin/user_reports/fix_associations.feature
@@ -26,7 +26,7 @@ Feature: Fix Associations
   Scenario: Broken invites as seen on the orphans page
     Given cookies are approved
     Given I am signed in as a superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     Then I should not see "normal"
     Then I should see "upcased"
     Then I should see "whitespace"
@@ -37,7 +37,7 @@ Feature: Fix Associations
     Given I run the fix invitations rake task
     Given cookies are approved
     Given I am signed in as a superadmin
-    And I visit the organisations without users page
+    And I visit the invite users to become admin of organisations page
     Then I should not see "normal"
     Then I should not see "upcased"
     Then I should not see "whitespace"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -25,7 +25,7 @@ Then(/^the SuperAdmin menu has a valid (.*?) link$/) do |link|
   within('#menuSuperAdmin > ul.dropdown-menu') do
     find('a', text: link).should_not be_nil
     click_link link
-    current_path.should eq paths(link.downcase)
+    current_path.should eq paths(link.downcase) # This line is failing
   end
 end
 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -25,7 +25,7 @@ Then(/^the SuperAdmin menu has a valid (.*?) link$/) do |link|
   within('#menuSuperAdmin > ul.dropdown-menu') do
     find('a', text: link).should_not be_nil
     click_link link
-    current_path.should eq paths(link.downcase) # This line is failing
+    current_path.should eq paths(link.downcase)
   end
 end
 

--- a/features/step_definitions/moderate_proposed_organisation_edit_steps.rb
+++ b/features/step_definitions/moderate_proposed_organisation_edit_steps.rb
@@ -1,8 +1,8 @@
-Given(/^I click on the all proposed edits link$/) do
-  click_link "All Proposed Edits"
+Given(/^I click on the pending proposed edits link$/) do
+  click_link "Pending Proposed Edits"
 end
 
-Then(/^I should not see the all proposed edits link$/) do
+Then(/^I should not see the pending proposed edits link$/) do
   page.should_not have_link href: proposed_organisation_edits_path
 end
 

--- a/features/step_definitions/moderate_proposed_organisation_steps.rb
+++ b/features/step_definitions/moderate_proposed_organisation_steps.rb
@@ -27,8 +27,8 @@ Then (/^I should( not)? see a "Reject Proposed Organisation" button$/) do |negat
   end
 end
 
-Then(/^I click on the all proposed organisations link$/) do
-  click_link "All Proposed Organisations"
+Then(/^I click on the pending proposed organisations link$/) do
+  click_link "Pending Proposed Organisations"
 end
 
 Then (/^I should not see an add organisation link$/) do

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -13,7 +13,7 @@ And /^I select the "(.*?)" category from (How They Help|Who They Help|What They 
   select(category, :from => cat_id)
 end
 
-When /^I visit the proposed organisation show page for the proposed organisation that was proposed$/ do 
+When /^I visit the proposed organisation show page for the proposed organisation that was proposed$/ do
   proposed_org = ProposedOrganisation.find_by(name: unsaved_proposed_organisation(User.first).name)
   visit proposed_organisation_path(proposed_org)
 end
@@ -33,8 +33,8 @@ def paths(location)
       'contributors' => contributors_path,
       'password reset' => edit_user_password_path,
       'invitation' => accept_user_invitation_path,
-      'organisations without users' => organisations_report_path,
-      'all users' => users_report_path,
+      'invite users to become admin of organisations' => organisations_report_path,
+      'registered users' => users_report_path,
       'invited users' => invited_users_report_path,
       'volunteer opportunities' => volunteer_ops_path,
       'contributors' => contributors_path,
@@ -72,7 +72,7 @@ Then /^I should be on the show organisation proposed edit page for the organisat
   current_path.should eq url
 end
 
-Then /^I (visit|should be on) the new volunteer op page for "(.*?)"$/ do |mode, name| 
+Then /^I (visit|should be on) the new volunteer op page for "(.*?)"$/ do |mode, name|
   org = Organisation.find_by_name(name)
   url = new_organisation_volunteer_op_path(org)
   case mode
@@ -209,7 +209,7 @@ Then(/^I should( not)? see the call to update details for organisation "(.*)"/) 
     end
 end
 Then(/^I should see an (active|inactive) home button in the header$/) do |active|
-    active_class = (active == "active") ? ".active" : "" 
+    active_class = (active == "active") ? ".active" : ""
     within('.nav.nav-pills.pull-right') do
       expect(page).to have_css("li#{active_class} > a[href='/']", :text => "Home")
     end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -129,7 +129,7 @@ describe 'layouts/application.html.erb', :type => :view do
         assign(:footer_page_links, [])
         render
         @absent_pages.each do |page|
-          expect(rendered).not_to have_link(page[:name], 
+          expect(rendered).not_to have_link(page[:name],
                                             :href => page_path(page[:permalink]))
         end
       end
@@ -137,11 +137,11 @@ describe 'layouts/application.html.erb', :type => :view do
       it 'shows a link to all of the editable pages' do
         render
         @pages.each do |page|
-          expect(rendered).to have_link(page[:name], 
+          expect(rendered).to have_link(page[:name],
                                         :href => page_path(page[:permalink]))
         end
         @absent_pages.each do |page|
-          expect(rendered).not_to have_link(page[:name], 
+          expect(rendered).not_to have_link(page[:name],
                                             :href => page_path(page[:permalink]))
         end
       end
@@ -186,8 +186,8 @@ describe 'layouts/application.html.erb', :type => :view do
 
     it 'should see superadmin-only dropdown' do
       rendered.within('#menuSuperAdmin') do |menu|
-        expect(menu).to have_link 'Organisations Without Users', :href => organisations_report_path
-        expect(menu).to have_link 'All Users', :href => users_report_path
+        expect(menu).to have_link 'Invite Users to become admin of Organisations', :href => organisations_report_path
+        expect(menu).to have_link 'Registered Users', :href => users_report_path
         expect(menu).to have_link 'Invited Users', :href => invited_users_report_path
       end
     end


### PR DESCRIPTION
New Admin options:
<img width="379" alt="new admin options" src="https://cloud.githubusercontent.com/assets/11786608/11686317/b676ab70-9e77-11e5-9e32-066aae053a37.png">

Previous admin options:
<img width="397" alt="previous admin options" src="https://cloud.githubusercontent.com/assets/11786608/11686389/3081ccc4-9e78-11e5-9001-d5f02939d42d.png">
