### PR TITLE
Improve the readability of proposed organisation edit page

### DIFF
--- a/app/views/proposed_organisation_edits/show.html.erb
+++ b/app/views/proposed_organisation_edits/show.html.erb
@@ -5,15 +5,15 @@
 
 <div class="row">
   <div class="span6">
-    <h3 class="<%= show_class('current', 'name') %>">
+    <h3 class="text-center">Current Information</h3>
+    <h4 class="<%= show_class('current', 'name') %>">
       <span class='field_value'>
       <%= @organisation.name %>
       </span>
-    </h3>
+    </h4>
     <p>
       <%= simple_format @organisation.description, class: show_class('current', 'description') %>
     </p>
-
     <% if @proposed_organisation_edit.viewable_field?(:address, by: current_user) %>
       <p class="<%= show_class('current', 'address') %>">
         <span><b>Address:</b></span>
@@ -72,17 +72,18 @@
         <div class="centered width_25">
           <%= form_for([@proposed_organisation_edit.organisation, @proposed_organisation_edit], :url => {:action => :update}) do |f| %>
             <%= f.hidden_field :id, value: @proposed_organisation_edit.id %>
-            <%= f.submit 'Reject Edit', :class => 'btn btn-primary' %>
+            <%= f.submit 'Keep Current Information', :class => 'btn btn-primary' %>
           <% end %>
         </div>
     <% end %>
   </div>
   <div class="span6">
-    <h3 class="<%= show_class('proposed', 'name') %>">
+    <h3 class="text-center">Proposed Edit</h3>
+    <h4 class="<%= show_class('proposed', 'name') %>">
       <span class="field_value">
       <%= @proposed_organisation_edit.name %>
       </span>
-    </h3>
+    </h4>
     <p>
       <span class="field_value">
       <%= simple_format @proposed_organisation_edit.description, class: show_class('proposed', 'description') %>
@@ -161,10 +162,9 @@
             <% if @proposed_organisation_edit.editable?(:email, by: @proposed_organisation_edit.editor)%>
             <%= f.hidden_field :email, value: @proposed_organisation_edit.email %>
             <% end %>
-            <%= f.submit 'Accept Edit', :class => 'btn btn-primary' %>
+            <%= f.submit 'Accept Edit', :class => 'btn btn-success' %>
           <% end %>
         </div>
     <% end %>
   </div>
 </div>
-

--- a/features/admin/admin_moderate_proposed_organisation_edits.feature
+++ b/features/admin/admin_moderate_proposed_organisation_edits.feature
@@ -17,7 +17,7 @@ Feature: Members of HCN may propose edits to organisations
       |original_name | editor_email                  | name       | description             | address        | postcode | telephone | website               | email                    | donation_info        | archived|
       |Friendly      | registered_user-2@example.com | Unfriendly | Mourning loved ones     | 30 pinner road | HA1 4HZ  | 520800000 | http://unfriendly.org | superadmin@unfriendly.xx | www.pleasedonate.com | false   |
       |Friendly      | registered_user-2@example.com | Unfriendly | Mourning loved ones     | 30 pinner road | HA1 4HZ  | 520800000 | http://unfriendly.org | superadmin@unfriendly.xx | www.pleasedonate.com | true    |
- 
+
     And cookies are approved
 
   Scenario: Nonsuperadmins do not see all proposed edits link
@@ -32,7 +32,7 @@ Feature: Members of HCN may propose edits to organisations
     And I should not see links for archived edits
     And I click on view details for the proposed edit for the organisation named "Friendly"
     And I should see a link or button "Accept Edit"
-    And I should see a link or button "Reject Edit"
+    And I should see a link or button "Keep Current Information"
 
   Scenario: Editability is enforced at moderate time even if it has changed since proposal of edit
     Given I am signed in as a superadmin
@@ -71,7 +71,7 @@ Feature: Members of HCN may propose edits to organisations
   Scenario: Reject a proposed edit
     Given I am signed in as a superadmin
     And I visit the most recently created proposed edit for "Friendly"
-    When I press "Reject Edit"
+    When I press "Keep Current Information"
     Then I should be on the show page for the organisation named "Friendly"
     And the most recently updated proposed edit for "Friendly" should be updated as follows:
       | archived | accepted |


### PR DESCRIPTION
Proposed Edit page:
<img width="1096" alt="proposed edit page" src="https://cloud.githubusercontent.com/assets/11786608/11711604/84595f86-9f1f-11e5-991b-84e09914e94f.png">

Current Edit page:
<img width="1275" alt="current edit page" src="https://cloud.githubusercontent.com/assets/11786608/11711610/8da1e41e-9f1f-11e5-97bf-e02cf9393417.png">

