### PR TITLE
Mailers - refactored

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,39 +1,33 @@
 class AdminMailer < ActionMailer::Base
 
+  # The default values for any email we send from AdminMailer.
+  # Any value can be overridden on a per-email basis.
+  default from: "support@harrowcn.org.uk",
+          cc: "technical@harrowcn.org.uk",
+          reply_to: "support@harrowcn.org.uk"
+
   def new_user_waiting_for_approval(org_name, superadmin_emails)
     @org_name = org_name
     mail(subject: "There is a user waiting for Admin approval to '#{org_name}'.",
-         to: superadmin_emails ,
-         from: "support@harrowcn.org.uk",
-         cc: "technical@harrowcn.org.uk",
-         reply_to: "support@harrowcn.org.uk")
+         to: superadmin_emails)
   end
 
   def new_user_sign_up(user_email, superadmin_emails)
     @user_email = user_email
     mail(subject: "A new user has joined Harrow Community Network",
-         to: superadmin_emails ,
-         from: "support@harrowcn.org.uk",
-         cc: "technical@harrowcn.org.uk",
-         reply_to: "support@harrowcn.org.uk")
+         to: superadmin_emails)
   end
 
   def new_org_waiting_for_approval(org, superadmin_emails)
     @org = org
     mail(subject: "A new organisation has been proposed for inclusion in Harrow Community Network",
-         to: superadmin_emails ,
-         from: "support@harrowcn.org.uk",
-         cc: "technical@harrowcn.org.uk",
-         reply_to: "support@harrowcn.org.uk")
+         to: superadmin_emails)
   end
 
   def edit_org_waiting_for_approval(org, superadmin_emails)
     @org = org
     mail(subject: "An edit to '#{org.name}' is awaiting Admin approval.",
-         to: superadmin_emails ,
-         from: "support@harrowcn.org.uk",
-         cc: "technical@harrowcn.org.uk",
-         reply_to: "support@harrowcn.org.uk")
+         to: superadmin_emails)
   end
 
 end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -4,6 +4,12 @@ class CustomDeviseMailer < Devise::Mailer
   helper :application # gives access to all helpers defined within `application_helper`.
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
+  # The default values for any email we send from CustomDeviseMailer.
+  # Any value can be overridden on a per-email basis.
+  default from: "support@harrowcn.org.uk",
+          cc: "technical@harrowcn.org.uk",
+          reply_to: "support@harrowcn.org.uk"
+
   # from devise_invitable-1.2.1/lib/devise_invitable/mailer.rb
   def invitation_instructions(record, token, opts={})
     opts[:cc] = 'technical@harrowcn.org.uk'
@@ -15,10 +21,7 @@ class CustomDeviseMailer < Devise::Mailer
     @org = org
     @resource = usr
     mail(subject: "Your organisation has been approved for inclusion in the Harrow Community Network!",
-         to: [email],
-         from: "support@harrowcn.org.uk",
-         cc: "technical@harrowcn.org.uk",
-         reply_to: "support@harrowcn.org.uk")
+         to: [email])
   end
 
 end

--- a/app/mailers/org_admin_mailer.rb
+++ b/app/mailers/org_admin_mailer.rb
@@ -1,23 +1,21 @@
 class OrgAdminMailer < ActionMailer::Base
 
+  # The default values for any email we send from OrgAdminMailer.
+  # Any value can be overridden on a per-email basis.
+  default from: "support@harrowcn.org.uk",
+          cc: "technical@harrowcn.org.uk",
+          reply_to: "support@harrowcn.org.uk"
+
   def new_org_admin(org, emails)
     @org = org
     mail(subject: "You have been made an organisation administrator on the Harrow Community Network",
-      to: emails ,
-      from: "support@harrowcn.org.uk",
-      cc: "technical@harrowcn.org.uk",
-      reply_to: "support@harrowcn.org.uk")
+         to: emails)
   end
 
   def notify_proposed_org_accepted(org, email)
     @org = org
     mail(subject:"Your Organisation has been accepted for inclusion on the Harrow Community Network",
-         to: [email],
-         from:"support@harrowcn.org.uk",
-         cc: "technical@harrowcn.org.uk",
-         reply_to:"support@harrowcn.org.uk")
+         to: [email])
   end
 
 end
-
-


### PR DESCRIPTION
All of the sent emails have the same 'from', 'cc', 'reply_to' email addresses. The code is refactored to minimises the repetition by having default email addresses for those fields. 

The pivotal tracker ticket is: https://www.pivotaltracker.com/projects/742821/stories/110899792 