### PR TITLE
Removed duplicate steps in invited_users_page.feature

### DIFF
--- a/features/admin/user_reports/invited_users_page.feature
+++ b/features/admin/user_reports/invited_users_page.feature
@@ -12,25 +12,19 @@ Feature: Invited Users Page
       | superadmin@myorg.com  | superadminpass0987  | true  | 2008-01-01 00:00:00 | My Organisation |                      |
       | regular@user.org | mypassword1234 | false | 2008-01-01 00:00:00 |                 |                      |
     And the superadmin invited a user for "Invited Organisation"
-
-  Scenario: Page shows only invited users
-    Given cookies are approved
+    And cookies are approved
     And I am signed in as a superadmin
     And I visit the invited users page
+
+  Scenario: Page shows only invited users
     Then I should see "invited@user.org"
     And I should not see "regular@user.org"
 
   Scenario: Super Admin can see the preview email
-    Given cookies are approved
-    And I am signed in as a superadmin
-    And I visit the invited users page
     Then I should see the preview email
 
   @javascript
   Scenario: Invitations can be resent
-    Given cookies are approved
-    Given I am signed in as a superadmin
-    And I visit the invited users page
-    And I check the box for "Invited Organisation"
+    Given I check the box for "Invited Organisation"
     When I click id "invite_users"
     Then I should see "Invited!" in the response field for "Invited Organisation"


### PR DESCRIPTION
There are three steps that are repeated in all of the scenarios in invited_users_page.feature. I have put them in the Background.

@tansaku in similar cases, is it good to remove the duplication? What if we add another test to the suite which will have different steps from the background? Should we be creating a separate file or depends :smile: 