### PR TITLE
Refactoring away from repositories and to CRUD named service objects

### DIFF
--- a/app/controllers/proposed_organisation_edits_controller.rb
+++ b/app/controllers/proposed_organisation_edits_controller.rb
@@ -10,7 +10,7 @@ class ProposedOrganisationEditsController < ApplicationController
   def create
     org = Organisation.find(params[:organisation_id])
     create_params = proposed_edit_params.merge!(organisation: org, editor: current_user)
-    proposed_org_edit = CreateProposedOrganisationEdit.with(listener: self, params: create_params)
+    proposed_org_edit = CreateProposedOrganisationEdit.with(self, create_params)
     redirect_to organisation_proposed_organisation_edit_path org, proposed_org_edit
   end
 

--- a/app/controllers/proposed_organisation_edits_controller.rb
+++ b/app/controllers/proposed_organisation_edits_controller.rb
@@ -36,6 +36,10 @@ class ProposedOrganisationEditsController < ApplicationController
     redirect_to organisation_path proposed_edit.organisation
   end
 
+  def set_notice(notice)
+    flash[:notice] = notice
+  end
+
   def update_params
     params.require(:proposed_organisation_edit).permit(:id)
   end

--- a/app/controllers/proposed_organisation_edits_controller.rb
+++ b/app/controllers/proposed_organisation_edits_controller.rb
@@ -10,7 +10,7 @@ class ProposedOrganisationEditsController < ApplicationController
   def create
     org = Organisation.find(params[:organisation_id])
     create_params = proposed_edit_params.merge!(organisation: org, editor: current_user)
-    proposed_org_edit = ProposedOrganisationEditRepository.create(self, create_params)
+    proposed_org_edit = CreateProposedOrganisationEdit.with(listener: self, params: create_params)
     redirect_to organisation_proposed_organisation_edit_path org, proposed_org_edit
   end
 
@@ -24,6 +24,7 @@ class ProposedOrganisationEditsController < ApplicationController
   end
 
   def update
+    # UpdateProposedOrganisationEdit.with(observer: self, params: create_params)
     proposed_edit = ProposedOrganisationEdit.find(update_params.fetch(:id))
     if proposed_edit_params.any?
       proposed_edit.accept(proposed_edit_params)

--- a/app/services/create_proposed_organisation_edit.rb
+++ b/app/services/create_proposed_organisation_edit.rb
@@ -1,6 +1,6 @@
-class ProposedOrganisationEditRepository
+class CreateProposedOrganisationEdit
 
-  def self.create(listener, params)
+  def self.with(listener: listener, params: params)
     unless params[:editor].siteadmin?
       merge_in_non_published_fields params[:organisation], params
       send_email_to_superadmin_about_org_edit params[:organisation]

--- a/app/services/create_proposed_organisation_edit.rb
+++ b/app/services/create_proposed_organisation_edit.rb
@@ -22,7 +22,7 @@ class CreateProposedOrganisationEdit
     unless editor.siteadmin?
       merge_in_non_published_fields
       send_email_to_superadmin_about_org_edit
-      listener.flash[:notice] = "Edit is pending admin approval."
+      listener.set_notice('Edit is pending admin approval.')
     end
     model_klass.create(params)
   end

--- a/app/services/create_proposed_organisation_edit.rb
+++ b/app/services/create_proposed_organisation_edit.rb
@@ -1,8 +1,12 @@
 class CreateProposedOrganisationEdit
 
   def self.with(listener, params, model_klass = ProposedOrganisationEdit, user_klass = User, mailer_klass = AdminMailer)
-    CreateProposedOrganisationEdit.new(listener, params, model_klass, user_klass, mailer_klass).run
+    new(listener, params, model_klass, user_klass, mailer_klass).send(:run)
   end
+
+  private
+
+  attr_reader :listener, :params, :organisation, :model_klass, :user_klass, :mailer_klass, :editor
 
   def initialize(listener, params, model_klass, user_klass, mailer_klass)
     @listener = listener
@@ -22,10 +26,6 @@ class CreateProposedOrganisationEdit
     end
     model_klass.create(params)
   end
-
-  private
-
-  attr_reader :listener, :params, :organisation, :model_klass, :user_klass, :mailer_klass, :editor
 
   def merge_in_non_published_fields
     in_memory_edit = ProposedOrganisationEdit.new(organisation: organisation)

--- a/app/services/create_proposed_organisation_edit.rb
+++ b/app/services/create_proposed_organisation_edit.rb
@@ -1,7 +1,12 @@
 class CreateProposedOrganisationEdit
 
-  def self.with(listener, params, model_klass = ProposedOrganisationEdit)
+  @user_klass = nil
+  @mailer_klass = nil
+
+  def self.with(listener, params, model_klass = ProposedOrganisationEdit, user_klass = User, mailer_klass = AdminMailer)
     unless params[:editor].siteadmin?
+      @user_klass = user_klass
+      @mailer_klass = mailer_klass
       merge_in_non_published_fields params[:organisation], params
       send_email_to_superadmin_about_org_edit params[:organisation]
       listener.flash[:notice] = "Edit is pending admin approval."
@@ -19,7 +24,7 @@ class CreateProposedOrganisationEdit
   end
 
   def self.send_email_to_superadmin_about_org_edit(org)
-    superadmin_emails = User.superadmins.pluck(:email)
-    AdminMailer.edit_org_waiting_for_approval(org, superadmin_emails).deliver_now
+    superadmin_emails = @user_klass.superadmins.pluck(:email)
+    @mailer_klass.edit_org_waiting_for_approval(org, superadmin_emails).deliver_now
   end
 end

--- a/app/services/create_proposed_organisation_edit.rb
+++ b/app/services/create_proposed_organisation_edit.rb
@@ -1,12 +1,12 @@
 class CreateProposedOrganisationEdit
 
-  def self.with(listener: listener, params: params)
+  def self.with(listener, params, model_klass = ProposedOrganisationEdit)
     unless params[:editor].siteadmin?
       merge_in_non_published_fields params[:organisation], params
       send_email_to_superadmin_about_org_edit params[:organisation]
       listener.flash[:notice] = "Edit is pending admin approval."
     end
-    ProposedOrganisationEdit.create(params)
+    model_klass.create(params)
   end
 
   private

--- a/spec/services/create_proposed_organisation_edit_spec.rb
+++ b/spec/services/create_proposed_organisation_edit_spec.rb
@@ -1,19 +1,20 @@
 require './app/services/create_proposed_organisation_edit'
 
 describe CreateProposedOrganisationEdit do
+  subject(:create_proposed_organisation_edit) { described_class.with(listener, params, model_klass, user_klass, mailer_class) }
 
   let(:model_klass) { spy(:proposed_organisation_edit) }
+  let(:user_klass) { double(:user_klass) }
+  let(:mailer_class) { double(:mailer_class) }
   let(:listener) { double :listener }
-  let(:params) { double :params }
+  let(:params) { {} }
+
+  before do
+    allow(params).to receive(:[]).with(:editor).and_return editor
+  end
 
   context 'editor is siteadmin' do
     let(:editor) { double :editor, siteadmin?: true }
-
-    before do
-      allow(params).to receive(:[]).with(:editor).and_return editor
-    end
-
-    subject(:create_proposed_organisation_edit) { described_class.with(listener, params, model_klass) }
 
     it 'creates a proposed organisation edit' do
       create_proposed_organisation_edit
@@ -22,7 +23,36 @@ describe CreateProposedOrganisationEdit do
   end
 
   context 'editor is not siteadmin' do
+    let(:editor) { double :editor, siteadmin?: false }
+    let(:organisation) { double :organisation }
 
+    before do
+      allow(params).to receive(:[]).with(:organisation).and_return organisation
+      allow(listener).to receive_message_chain :flash, :[]=
+      allow(described_class).to receive :merge_in_non_published_fields
+      allow(user_klass).to receive_message_chain :superadmins, :pluck
+      allow(mailer_class).to receive_message_chain :edit_org_waiting_for_approval, :deliver_now
+    end
+
+    it 'merges in non published fields' do
+      expect(described_class).to receive :merge_in_non_published_fields
+      create_proposed_organisation_edit
+    end
+
+    it 'sends email to superadmin about org edit' do
+      expect(mailer_class).to receive_message_chain :edit_org_waiting_for_approval, :deliver_now
+      create_proposed_organisation_edit
+    end
+
+    it 'sets the flash notice on the listener' do
+      expect(listener).to receive_message_chain :flash, :[]=
+      create_proposed_organisation_edit
+    end
+
+    it 'creates a proposed organisation edit' do
+      create_proposed_organisation_edit
+      expect(model_klass).to have_received(:create).with(params)
+    end
   end
 
 end

--- a/spec/services/create_proposed_organisation_edit_spec.rb
+++ b/spec/services/create_proposed_organisation_edit_spec.rb
@@ -1,0 +1,28 @@
+require './app/services/create_proposed_organisation_edit'
+
+describe CreateProposedOrganisationEdit do
+
+  let(:model_klass) { spy(:proposed_organisation_edit) }
+  let(:listener) { double :listener }
+  let(:params) { double :params }
+
+  context 'editor is siteadmin' do
+    let(:editor) { double :editor, siteadmin?: true }
+
+    before do
+      allow(params).to receive(:[]).with(:editor).and_return editor
+    end
+
+    subject(:create_proposed_organisation_edit) { described_class.with(listener, params, model_klass) }
+
+    it 'creates a proposed organisation edit' do
+      create_proposed_organisation_edit
+      expect(model_klass).to have_received(:create).with(params)
+    end
+  end
+
+  context 'editor is not siteadmin' do
+
+  end
+
+end

--- a/spec/services/create_proposed_organisation_edit_spec.rb
+++ b/spec/services/create_proposed_organisation_edit_spec.rb
@@ -6,7 +6,7 @@ describe CreateProposedOrganisationEdit do
   let(:model_klass) { spy(:proposed_organisation_edit) }
   let(:user_klass) { double(:user_klass) }
   let(:mailer_class) { double(:mailer_class) }
-  let(:listener) { double :listener }
+  let(:listener) { spy :listener }
   let(:organisation) { double :organisation }
   let(:params) { { editor: editor, organisation: organisation } }
 
@@ -42,8 +42,8 @@ describe CreateProposedOrganisationEdit do
     end
 
     it 'sets the flash notice on the listener' do
-      expect(listener).to receive_message_chain :flash, :[]=
       create_proposed_organisation_edit
+      expect(listener).to have_received(:set_notice).with('Edit is pending admin approval.')
     end
 
     it 'creates a proposed organisation edit' do

--- a/spec/services/create_proposed_organisation_edit_spec.rb
+++ b/spec/services/create_proposed_organisation_edit_spec.rb
@@ -25,13 +25,13 @@ describe CreateProposedOrganisationEdit do
 
     before do
       allow(listener).to receive_message_chain :flash, :[]=
-      allow(described_class).to receive :merge_in_non_published_fields
+      allow_any_instance_of(described_class).to receive :merge_in_non_published_fields
       allow(user_klass).to receive_message_chain(:superadmins, :pluck).and_return(:admins)
       allow(mailer_class).to receive_message_chain :edit_org_waiting_for_approval, :deliver_now
     end
 
     it 'merges in non published fields' do
-      expect(described_class).to receive :merge_in_non_published_fields
+      expect_any_instance_of(described_class).to receive :merge_in_non_published_fields
       create_proposed_organisation_edit
     end
 


### PR DESCRIPTION
I had 2nd thoughts on repositories after talking to @pitchinvasion and @silvabox.  Am thinking now that maybe service objects named after CRUD operations would be better.  Also I'm liking the service object naming convention that @silvabox describes here: 

http://blog.silvabox.com/musings-on-service-objects/

I'll be particularly interested in @mtc2013,  @johnnymo87 and @marianmosley 's thoughts on this approach.  Perhaps we might refactor a few other service objects towards this naming scheme?


p.s. trying to use the pivotal/github integration thing again:  https://blog.pivotal.io/pivotal-labs/labs/level-up-your-development-workflow-with-github-pivotal-tracker