### PR TITLE
Added well, background colour to preview_email in admin tab

### DIFF
--- a/app/assets/stylesheets/without_users.css
+++ b/app/assets/stylesheets/without_users.css
@@ -15,6 +15,11 @@ table th, table td { overflow: hidden; }
     width: 100%;
 }
 
+#preview_email {
+  font-size: 80%;
+  background-color: white;
+}
+
 tr.actions-right > td:last-child {
   width: 180px;
 }

--- a/app/views/organisation_reports/without_users_index.html.erb
+++ b/app/views/organisation_reports/without_users_index.html.erb
@@ -1,7 +1,7 @@
 <p><b> The Following email will be sent when a user is invited: </b></p>
-<p>
+<div class="well" id="preview_email">
   <%= render template: 'custom_devise_mailer/invitation_instructions', :locals => { :@resource => User.new } %>
-</p>
+</div>
 <table class="table table-hover sortable">
   <thead>
   <tr>

--- a/app/views/user_reports/invited.html.erb
+++ b/app/views/user_reports/invited.html.erb
@@ -1,7 +1,7 @@
 <p><b> The Following email will be sent when a user is invited: </b></p>
-<p>
+<div class="well" id="preview_email">
   <%= render template: 'custom_devise_mailer/invitation_instructions', :locals => { :@resource => User.new } %>
-</p>
+</div>
 <table class="table table-hover sortable">
   <thead>
   <tr>


### PR DESCRIPTION
I have added a well and styled it with a background colour(white) for both preview emails in admin tab:
1) Invite Users to become admin of Organisations
2) Invited Users.

This is the ticket: https://www.pivotaltracker.com/story/show/111677748