### PR TITLE
removes trailing backslash

### DIFF
--- a/app/views/proposed_organisation_edits/show.html.erb
+++ b/app/views/proposed_organisation_edits/show.html.erb
@@ -152,7 +152,7 @@
             <%= f.hidden_field :description, value: @proposed_organisation_edit.description %>
             <%= f.hidden_field :donation_info, value: @proposed_organisation_edit.donation_info %>
             <% if @proposed_organisation_edit.editable?(:address, by: @proposed_organisation_edit.editor) %>
-            <%= f.hidden_field :address, value: @proposed_organisation_edit.address %>\
+            <%= f.hidden_field :address, value: @proposed_organisation_edit.address %>
             <% end %>
             <%= f.hidden_field :postcode, value: @proposed_organisation_edit.postcode %>
             <% if @proposed_organisation_edit.editable?(:telephone, by: @proposed_organisation_edit.editor)%>


### PR DESCRIPTION
There was a trailing '/' next to the 'Accept' button in the proposed organisation edit page.

This is the ticket: https://www.pivotaltracker.com/story/show/111677954