### PR TITLE
Clearing up noise in RSpec log

### DIFF
--- a/spec/migrations/add_link_visible_flag_to_page_spec.rb
+++ b/spec/migrations/add_link_visible_flag_to_page_spec.rb
@@ -10,7 +10,7 @@ migration_file_name =
       join('db/migrate/*_add_link_visible_flag_to_page.rb')].first
 require migration_file_name
 
-
+ActiveRecord::Migration.verbose = false
 
 describe AddLinkVisibleFlagToPage do
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -288,7 +288,7 @@ describe Organisation, :type => :model do
       fields = CSV.parse('HARROW BAPTIST CHURCH,1129832,NO INFORMATION RECORDED,MR JOHN ROSS NEWBY,"HARROW BAPTIST CHURCH, COLLEGE ROAD, HARROW, HA1 4HZ",http://www.harrow-baptist.org.uk,020 8863 7837,2009-05-27,,,,,,http://OpenlyLocal.com/charities/57879-HARROW-BAPTIST-CHURCH,,,,,"207,305,108,302,306",false,2010-09-20T21:38:52+01:00,2010-08-22T22:19:07+01:00,2012-04-15T11:22:12+01:00,*****')
       expect(lambda{
         org = create_organisation(fields)
-      }).to raise_error
+      }).to raise_error CSV::MalformedCSVError
     end
 
 

--- a/spec/models/proposed_organisation_spec.rb
+++ b/spec/models/proposed_organisation_spec.rb
@@ -13,7 +13,7 @@ describe ProposedOrganisation, :type => :model do
     end
     it 'expunges the proposed organisation' do
       expect(proposed_org.id).to eq new_org.id
-      expect{ProposedOrganisation.find proposed_org.id}.to raise_error
+      expect{ProposedOrganisation.find proposed_org.id}.to raise_error ActiveRecord::RecordNotFound
     end
     [:name, :description, :address, :longitude, :latitude, :email, :postcode, :publish_email, :publish_phone,
     :donation_info, :website, :publish_address, :telephone].each do |attr|


### PR DESCRIPTION
As described in https://www.pivotaltracker.com/story/show/103015790 we had a few bits and pieces cluttering up our RSpec output.

This pull request adds specific error checking to a couple of specs that were just checking for generic errors, and quietens the log output from a migration test.

It doesn't address the 'Google Geocoding API error: over query limit.' message, since that feels like it is closely related to some of the other work going on at the moment in #219 and #216 

I tracked down a specific culprit, e.g. rspec spec/controllers/volunteer_ops_controller_spec.rb:43 which is directly testing a private method (not so good) and I think we should be dropping controller specs anyway.  That spec file should probably be reviewed and tests that hit endpoints with get/post etc. could be moved out to request specs?  

Or are some people calling those things controller specs hmm.  @sdorunga said something to that effect.  Either way we need to choose one approach and stick to it.  I definitely thing we should remove RSpecs that test controller logic independently of a specific endpoint request (i.e. get/post to a URI).  Whether we have those in controller or request directories is not such a big deal as long as we are consistent.