### PR TITLE
Change expired token message when resetting password

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -8,7 +8,13 @@ module DeviseHelper
   def devise_error_messages!
     return "" if resource.errors.empty?
 
-    messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
+    errors = resource.errors
+    if errors[:reset_password_token] and errors[:reset_password_token].include? "has expired, please request a new one"
+      errors.add(:base, :reset_password_token_expired)
+      errors[:reset_password_token].delete "has expired, please request a new one"
+    end
+      
+    messages = errors.full_messages.map { |msg| content_tag(:li, msg) }.join
 
     # empty out error messages so they don't linger
     resource.errors.clear

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -57,3 +57,10 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            reset_password_token:
+              expired: 'reset requested too long ago - please request a new reset by clicking "forgot password" again'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -61,6 +61,6 @@ en:
     errors:
       models:
         user:
+          reset_password_token_expired: 'Reset requested too long ago - please request a new reset by clicking "forgot password" again'
           attributes:
             reset_password_token:
-              expired: 'reset requested too long ago - please request a new reset by clicking "forgot password" again'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,5 +8,9 @@ en:
       organisation: Organisation
   authorize:
     superadmin: 'You must be signed in as a superadmin to perform this action!'
+  devise:
+    errors:
+      messages:
+        expired: 'reset requested too long ago - please request a new reset by clicking "forgot password" again'
 
 

--- a/features/custom_error_pages.feature
+++ b/features/custom_error_pages.feature
@@ -22,3 +22,9 @@ Feature: I want to make error pages follow the general design of the site.
     Then the page should be titled "500 Internal Server Error"
     And the response status should be "500"
     And I should see "We're sorry, but something went wrong."
+
+  Scenario: reset_password_token expired message
+    Given I requested a new password too long ago
+    When I visit the reset password page
+    And I try to reset my password
+    Then I should see "Reset requested too long ago - please request a new reset by clicking "forgot password" again" within "error_explanation"

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -38,7 +38,8 @@ def paths(location)
       'invited users' => invited_users_report_path,
       'volunteer opportunities' => volunteer_ops_path,
       'contributors' => contributors_path,
-      'deleted users' => deleted_users_report_path
+      'deleted users' => deleted_users_report_path,
+      'reset password' => "/users/password/edit?reset_password_token=#{@reset_password_token}"
   }[location]
 end
 

--- a/features/step_definitions/reset_password_token_steps.rb
+++ b/features/step_definitions/reset_password_token_steps.rb
@@ -1,0 +1,12 @@
+Given(/^I requested a new password too long ago$/) do
+  user = FactoryGirl.create(:user)
+  @reset_password_token = user.send_reset_password_instructions
+  user.reset_password_sent_at = 1.year.ago
+  user.save!
+end
+
+And(/^I try to reset my password$/) do
+  fill_in('user_password', :with => 'AbRaCaDaBrA123', :match => :prefer_exact)
+  fill_in('Confirm new password', :with => 'AbRaCaDaBrA123')
+  click_button 'Change my password'
+end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -64,7 +64,7 @@ describe Devise::PasswordsController, :type => :controller do
          put :update, user:
            { reset_password_token: reset_password_token, password: '123qwe___', password_confirmation: '123qwe___' }
 #         expect(response.body).to have_content('Reset password token has expired, please request a new one')
-         expect(assigns(:user).errors.full_messages).to include "Reset password token has expired, please request a new one"
+         expect(assigns(:user).errors.full_messages).to include 'reset requested too long ago - please request a new reset by clicking "forgot password" again'
        end
      end
    end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -48,24 +48,12 @@ describe Devise::PasswordsController, :type => :controller do
        end
      end
      context 'unsuccessfully' do
-       render_views
+#      render_views
        it 'incorrect reset password token' do
          put :update, user:
            { reset_password_token: 'abracadabra', password: '123qwe___', password_confirmation: '123qwe___' }
-#        expect(assigns(:user).errors.full_messages).to include "Reset password token is invalid"
-         expect(response.body).to have_content('Reset password token is invalid')
-       end
-       it 'expires token' do
-
-         user = FactoryGirl.create(:user)
-         reset_password_token = user.send_reset_password_instructions
-         user.reset_password_sent_at = 1.year.ago
-         user.save!
-         user.reload
-         put :update, user:
-           { reset_password_token: reset_password_token, password: '123qwe___', password_confirmation: '123qwe___' }
-         expect(response.body).to have_content('Reset requested too long ago - please request a new reset by clicking "forgot password" again')
-#        expect(assigns(:user).errors.full_messages).to include 'reset requested too long ago - please request a new reset by clicking "forgot password" again'
+         expect(assigns(:user).errors.full_messages).to include "Reset password token is invalid"
+#        expect(response.body).to have_content('Reset password token is invalid')
        end
      end
    end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -48,11 +48,12 @@ describe Devise::PasswordsController, :type => :controller do
        end
      end
      context 'unsuccessfully' do
-#      render_views
+       render_views
        it 'incorrect reset password token' do
          put :update, user:
            { reset_password_token: 'abracadabra', password: '123qwe___', password_confirmation: '123qwe___' }
-         expect(assigns(:user).errors.full_messages).to include "Reset password token is invalid"
+#        expect(assigns(:user).errors.full_messages).to include "Reset password token is invalid"
+         expect(response.body).to have_content('Reset password token is invalid')
        end
        it 'expires token' do
 
@@ -63,8 +64,8 @@ describe Devise::PasswordsController, :type => :controller do
          user.reload
          put :update, user:
            { reset_password_token: reset_password_token, password: '123qwe___', password_confirmation: '123qwe___' }
-#         expect(response.body).to have_content('Reset password token has expired, please request a new one')
-         expect(assigns(:user).errors.full_messages).to include 'reset requested too long ago - please request a new reset by clicking "forgot password" again'
+         expect(response.body).to have_content('Reset requested too long ago - please request a new reset by clicking "forgot password" again')
+#        expect(assigns(:user).errors.full_messages).to include 'reset requested too long ago - please request a new reset by clicking "forgot password" again'
        end
      end
    end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -33,4 +33,39 @@ describe Devise::PasswordsController, :type => :controller do
       end
     end
    end
+   describe 'PATCH update' do
+     before :each do
+       request.env["devise.mapping"] = Devise.mappings[:user]
+     end
+     let(:user){ FactoryGirl.create(:user) }
+     let(:reset_password_token){ user.send_reset_password_instructions }
+     subject(:change_password){ put :update, user:
+       { reset_password_token: reset_password_token, password: '123qwe___', password_confirmation: '123qwe___' } }
+     context 'successfully' do
+       it 'changes password' do
+         change_password
+         expect(flash[:notice]).to eq('Your password was changed successfully. You are now signed in.')
+       end
+     end
+     context 'unsuccessfully' do
+#      render_views
+       it 'incorrect reset password token' do
+         put :update, user:
+           { reset_password_token: 'abracadabra', password: '123qwe___', password_confirmation: '123qwe___' }
+         expect(assigns(:user).errors.full_messages).to include "Reset password token is invalid"
+       end
+       it 'expires token' do
+
+         user = FactoryGirl.create(:user)
+         reset_password_token = user.send_reset_password_instructions
+         user.reset_password_sent_at = 1.year.ago
+         user.save!
+         user.reload
+         put :update, user:
+           { reset_password_token: reset_password_token, password: '123qwe___', password_confirmation: '123qwe___' }
+#         expect(response.body).to have_content('Reset password token has expired, please request a new one')
+         expect(assigns(:user).errors.full_messages).to include "Reset password token has expired, please request a new one"
+       end
+     end
+   end
 end


### PR DESCRIPTION
I had to change devise helper to change message, because errors.full_messages return array of strings where strings have been built as "%{attribute} %{message}". I cannot get rid of 'Reset password token' mention otherwise.