### PR TITLE
Try to extract marker builder

### DIFF
--- a/app/controllers/volunteer_ops_controller.rb
+++ b/app/controllers/volunteer_ops_controller.rb
@@ -58,21 +58,12 @@ class VolunteerOpsController < ApplicationController
   private
 
   def build_map_markers(organisations)
-    ::MapMarkerJson.build(organisations) do |org, marker|
-      marker.lat org.latitude
-      marker.lng org.longitude
-      marker.infowindow render_to_string( partial: 'popup', locals: {org: org})
-      marker.json(
-        custom_marker: render_to_string(
-          partial: 'shared/custom_marker',
-          locals: { attrs: [ActionController::Base.helpers.asset_path("volunteer_icon.png"),
-                    'data-id' => org.id,
-                    class: 'vol_op', title: "Click here to see volunteer opportunities at #{org.name}"]}
-        ),
-        index: 1,
-        type: 'vol_op'
-      )
-    end
+    VolunteerOpMarkerBuilder.new(
+      organisations,
+      self,
+      MapMarkerJson,
+      ActionController::Base.helpers,
+    ).perform
   end
 
   def authorize

--- a/app/services/volunteer_op_marker_builder.rb
+++ b/app/services/volunteer_op_marker_builder.rb
@@ -1,0 +1,40 @@
+class VolunteerOpMarkerBuilder
+  def initialize(organisations, listener, marker_builder, url_helper)
+    @organisations = organisations
+    @marker_builder = marker_builder
+    @listener = listener
+    @url_helper = url_helper
+  end
+
+  def perform
+    marker_builder.build(organisations) do |org, marker|
+      marker.lat org.latitude
+      marker.lng org.longitude
+      marker.infowindow listener.render_to_string(partial: 'popup', locals: { org: org })
+      marker.json(
+        custom_marker: listener.render_to_string(
+          partial: 'shared/custom_marker',
+          locals: {
+            attrs: [
+              url_helper.asset_path("volunteer_icon.png"),
+              {
+                'data-id' => org.id,
+                'class'   => 'vol_op',
+                'title'   => "Click here to see volunteer opportunities at #{org.name}"
+              }
+            ]
+          }
+        ),
+        index: 1,
+        type: 'vol_op'
+      )
+    end
+  end
+
+  private
+
+  attr_reader :organisations,
+    :marker_builder,
+    :listener,
+    :url_helper
+end


### PR DESCRIPTION
I was hoping to be able to cleanly extract this logic to a service, and test it there in isolation from the controller (although not mock test it). It turns out I can't easily do this because `render_to_string` is pretty essential to the logic, and I need the controller to do this. In my non-controller tests (not commited), I tried to inject `VolunteerOpsController.new`, but this fails at:
```
listener.render_to_string(partial: 'popup', locals: { org: org })
*** ActionView::Template::Error Exception: undefined method `host' for nil:NilClass
```
I believe that there's methods in the partial that need a somehow more realistic controller instance to function.

So I'm just marking this WIP, and I'll probably try a different approach to the problem later. 