### PR TITLE
Gets proposed orgs set up to handle validations

### DIFF
--- a/app/controllers/proposed_organisations_controller.rb
+++ b/app/controllers/proposed_organisations_controller.rb
@@ -28,11 +28,12 @@ class ProposedOrganisationsController < BaseOrganisationsController
 
   def create
     make_user_into_org_admin_of_new_proposed_org
-    if @proposed_organisation.save!
+    if @proposed_organisation.save
       session[:proposed_organisation_id] = @proposed_organisation.id
       send_email_to_superadmin_about_org_signup @proposed_organisation
       redirect_to @proposed_organisation, notice: 'Organisation is pending admin approval.'
     else
+      flash[:error] = @proposed_organisation.errors.full_messages.join('<br/>').html_safe
       redirect_to new_proposed_organisation_path and return false
     end
   end

--- a/features/individual_charity_pages/propose_new_organisation.feature
+++ b/features/individual_charity_pages/propose_new_organisation.feature
@@ -28,6 +28,14 @@ Feature: User proposes an organisation to be added to HarrowCN
     And I visit the home page
     Then I should not see an add organisation link
 
+  @vcr
+  Scenario: Get validation error proposing new charity
+    Given I click "Add Organisation"
+    Then I should be on the new proposed organisation page
+    And I press "Create Proposed organisation"
+    Then I should see "Name can't be blank"
+    Then I should see "Description can't be blank"
+
   @javascript @vcr @billy
   Scenario: Unregistered user proposes new organisation
     Given I click "Add Organisation"


### PR DESCRIPTION
If I'd done a more thorough check I would have caught this without letting it get into develop.  I had the feature flags incorrectly set locally so I didn't have a quick link to submit a proposed org for an unregistered user.

Poor excuse perhaps, but a good cautionary tale ...

TODO
-------

* [ ] get my local feature flags sorted
* [ ] review the overgrowth in the associated cucumber tests --> is it appropriate to check for validations there?
* [ ] check the proposed org acceptance process as well?