### PR TITLE
Add docs to main repo [Fixes #115032541]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = https://github.com/AgileVentures/LocalSupport.wiki.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ deploy:
     staging: harrowcn-staging
     master: harrowcn-production
   run: rake db:migrate
+git:
+  submodules: false


### PR DESCRIPTION
- added wiki repo in docs directory as submodule
- Config travis to ignore git submodule

for more information check this blog (http://brendancleary.com/2013/03/08/including-a-github-wiki-in-a-repository-as-a-submodule/)