### PR TITLE
Adds friendly_id feature (2nd attempt) [PT #89294872]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,3 +99,6 @@ gem "paranoia", "~> 2.0"
 
 gem 'dotenv-rails'
 gem 'airbrake'
+
+# Using user friendly names in URLs
+gem 'friendly_id', '~> 5.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     ffi (1.9.10)
     font-awesome-rails (4.3.0.0)
       railties (>= 3.2, < 5.0)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     geocoder (1.2.10)
     gherkin (2.12.2)
       multi_json (~> 1.3)
@@ -383,6 +385,7 @@ DEPENDENCIES
   execjs
   factory_girl_rails
   font-awesome-rails
+  friendly_id (~> 5.1.0)
   geocoder
   gmaps4rails (= 2.1.2)
   heroku-api

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -27,8 +27,8 @@ class OrganisationsController < BaseOrganisationsController
   # GET /organisations/1
   # GET /organisations/1.json
   def show
-    organisations = Organisation.where(id: params[:id])
-    @organisation = organisations.first!
+    @organisation = Organisation.friendly.find(params[:id])
+    organisations = Organisation.where(id: @organisation.id)
     @pending_org_admin = current_user.pending_org_admin? @organisation if current_user
     @editable = current_user.can_edit?(@organisation) if current_user
     @deletable = current_user.can_delete?(@organisation) if current_user
@@ -49,8 +49,8 @@ class OrganisationsController < BaseOrganisationsController
   
   # GET /organisations/1/edit
   def edit
-    organisations = Organisation.where(id: params[:id])
-    @organisation = organisations.first!
+    @organisation = Organisation.friendly.find(params[:id])
+    organisations = Organisation.where(id: @organisation.id)
     @markers = build_map_markers(organisations)
     @categories_start_with = Category.first_category_name_in_each_type
     return false unless user_can_edit? @organisation

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -87,7 +87,7 @@ class OrganisationsController < BaseOrganisationsController
   # PUT /organisations/1
   # PUT /organisations/1.json
   def update
-    @organisation = Organisation.find(params[:id])
+    @organisation = Organisation.friendly.find(params[:id])
     params[:organisation][:superadmin_email_to_add] = params[:organisation_superadmin_email_to_add] if params[:organisation]
     update_params = OrganisationParams.build params
     return false unless user_can_edit? @organisation
@@ -106,7 +106,7 @@ class OrganisationsController < BaseOrganisationsController
       flash[:notice] = PERMISSION_DENIED
       redirect_to organisation_path(params[:id]) and return false
     end
-    @organisation = Organisation.find(params[:id])
+    @organisation = Organisation.friendly.find(params[:id])
     @organisation.destroy
     flash[:success] = "Deleted #{@organisation.name}"
 

--- a/app/controllers/proposed_organisation_edits_controller.rb
+++ b/app/controllers/proposed_organisation_edits_controller.rb
@@ -3,7 +3,7 @@ class ProposedOrganisationEditsController < ApplicationController
   before_filter :authorize, :only => [:update]
 
   def new
-    org = Organisation.find_by_id params[:organisation_id]
+    org = Organisation.friendly.find params[:organisation_id]
     @proposed_organisation_edit = ProposedOrganisationEdit.new organisation: org
   end
 
@@ -15,8 +15,7 @@ class ProposedOrganisationEditsController < ApplicationController
   end
 
   def show
-    # TODO Friendly_id may be implemented?
-    @organisation = Organisation.find(params[:organisation_id])
+    @organisation = Organisation.friendly.find(params[:organisation_id])
     @proposed_organisation_edit = ProposedOrganisationEdit.find(params[:id])
   end
 

--- a/app/controllers/proposed_organisation_edits_controller.rb
+++ b/app/controllers/proposed_organisation_edits_controller.rb
@@ -8,13 +8,14 @@ class ProposedOrganisationEditsController < ApplicationController
   end
 
   def create
-    org = Organisation.find(params[:organisation_id])
+    org = Organisation.friendly.find(params[:organisation_id])
     create_params = proposed_edit_params.merge!(organisation: org, editor: current_user)
     proposed_org_edit = CreateProposedOrganisationEdit.with(self, create_params)
     redirect_to organisation_proposed_organisation_edit_path org, proposed_org_edit
   end
 
   def show
+    # TODO Friendly_id may be implemented?
     @organisation = Organisation.find(params[:organisation_id])
     @proposed_organisation_edit = ProposedOrganisationEdit.find(params[:id])
   end

--- a/app/controllers/proposed_organisations_controller.rb
+++ b/app/controllers/proposed_organisations_controller.rb
@@ -8,14 +8,14 @@ class ProposedOrganisationsController < BaseOrganisationsController
   end
 
   def update
-    proposed_org = ProposedOrganisation.find params[:id]
+    proposed_org = ProposedOrganisation.friendly.find params[:id]
     result = AcceptProposedOrganisation.new(proposed_org).run
     set_flash_for_accepting_proposed_org result
     redirect_to organisation_path(result.accepted_organisation) and return false
   end
 
   def destroy
-    proposed_org = ProposedOrganisation.find params[:id]
+    proposed_org = ProposedOrganisation.friendly.find params[:id]
     proposed_org.destroy
     redirect_to proposed_organisations_path
   end
@@ -46,8 +46,8 @@ class ProposedOrganisationsController < BaseOrganisationsController
   end
 
   def show
-    proposed_organisations = ProposedOrganisation.where(id: params[:id])
-    @proposed_organisation = proposed_organisations.first!
+    @proposed_organisation = ProposedOrganisation.friendly.find(params[:id])
+    proposed_organisations = ProposedOrganisation.where(id: @proposed_organisation.id)
     #refactor this into model
     @proposer_email = @proposed_organisation.users.first.email if !@proposed_organisation.users.empty?
     @markers = build_map_markers(proposed_organisations)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -17,7 +17,7 @@ class RegistrationsController < Devise::RegistrationsController
     def after_inactive_sign_up_path_for(resource)
       if session[:pending_organisation_id]
         UserOrganisationClaimer.new(self, resource, resource).call(session[:pending_organisation_id])
-        return organisation_path resource.pending_organisation_id 
+        return organisation_path resource.pending_organisation 
       elsif session[:proposed_org]
         session[:user_id] =  resource.id
         return new_proposed_organisation_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
   end
 
   def update_message_for_admin_status
-    org = Organisation.find(UserParams.build(params).fetch(:pending_organisation_id))
+    org = Organisation.friendly.find(UserParams.build(params).fetch(:pending_organisation_id))
     flash[:notice] = "You have requested admin status for #{org.name}"
     send_email_to_superadmin_about_request_for_admin_of org   # could be moved to an hook on the user model?
     redirect_to organisation_path(UserParams.build(params).fetch(:pending_organisation_id))

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,15 +8,16 @@ class UsersController < ApplicationController
   # and only superadmins should be allowed to update organisation_id
   # makes me think of a attributes permissions matrix
   def update
+    org = Organisation.friendly.find(params[:pending_organisation_id])
     usr = User.find_by_id UserParams.build(params).fetch(:id)
-    UserOrganisationClaimer.new(self, usr, usr).call(UserParams.build(params).fetch(:pending_organisation_id))
+    UserOrganisationClaimer.new(self, usr, usr).call(org.id)
   end
 
   def update_message_for_admin_status
-    org = Organisation.friendly.find(UserParams.build(params).fetch(:pending_organisation_id))
+    org = Organisation.friendly.find(params[:pending_organisation_id])
     flash[:notice] = "You have requested admin status for #{org.name}"
     send_email_to_superadmin_about_request_for_admin_of org   # could be moved to an hook on the user model?
-    redirect_to organisation_path(UserParams.build(params).fetch(:pending_organisation_id))
+    redirect_to organisation_path(org)
   end
 
   def send_email_to_superadmin_about_request_for_admin_of org

--- a/app/controllers/volunteer_ops_controller.rb
+++ b/app/controllers/volunteer_ops_controller.rb
@@ -19,8 +19,8 @@ class VolunteerOpsController < ApplicationController
   def show
     @volunteer_ops = VolunteerOp.where(id: params[:id])
     @volunteer_op = @volunteer_ops.first
-    organisations = Organisation.where(id: @volunteer_op.organisation_id)
-    @organisation = organisations.first!
+    @organisation = Organisation.friendly.find(@volunteer_op.organisation_id)
+    organisations = Organisation.where(id: @organisation.id)
     @editable = current_user.can_edit?(@organisation) if current_user
 
     @markers = BuildMarkersWithInfoWindow.with(@volunteer_ops,self)
@@ -31,7 +31,8 @@ class VolunteerOpsController < ApplicationController
   end
 
   def create
-    params[:volunteer_op][:organisation_id] = params[:organisation_id]
+    org = Organisation.friendly.find(params[:organisation_id])
+    params[:volunteer_op][:organisation_id] = org.id
     @volunteer_op = VolunteerOp.new(volunteer_op_params)
     if @volunteer_op.save
       redirect_to @volunteer_op, notice: 'Volunteer op was successfully created.'

--- a/app/controllers/volunteer_ops_controller.rb
+++ b/app/controllers/volunteer_ops_controller.rb
@@ -89,7 +89,7 @@ class VolunteerOpsController < ApplicationController
 
   def org_owner?
     if params[:organisation_id].present? && current_user.present? && current_user.organisation.present?
-      current_user.organisation.id.to_s == params[:organisation_id]
+      current_user.organisation.friendly_id == params[:organisation_id]
     else
       current_user.organisation == VolunteerOp.find(params[:id]).organisation if current_user.present? && current_user.organisation.present?
     end

--- a/app/models/base_organisation.rb
+++ b/app/models/base_organisation.rb
@@ -1,4 +1,7 @@
 class BaseOrganisation < ActiveRecord::Base
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+  
   acts_as_paranoid
   validates_url :website, prefferred_scheme: 'http://', message: 'Website is not a valid URL',
     if: proc{|org| org.website.present?}

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -9,19 +9,19 @@
 <div id="org-cat-buttons" class="row">
   <div class="position-bottom span6">
     <% if @editable %>
-        <%= link_to("Edit", edit_organisation_path(@organisation.id), {:class => 'btn btn-primary'}) %>
+        <%= link_to("Edit", edit_organisation_path(@organisation), {:class => 'btn btn-primary'}) %>
     <% end %>
     <% if @can_propose_edits %>
-        <%= link_to("Propose an edit", new_organisation_proposed_organisation_edit_path(@organisation.id) , {:class => 'btn btn-primary'})%>
+        <%= link_to("Propose an edit", new_organisation_proposed_organisation_edit_path(@organisation) , {:class => 'btn btn-primary'})%>
     <% end %>
     <% if @deletable %>
-        <%= link_to("Delete", organisation_path(@organisation.id), {method: :delete, :class => 'btn btn-danger'}) %>
+        <%= link_to("Delete", organisation_path(@organisation), {method: :delete, :class => 'btn btn-danger'}) %>
     <% end %>
     <% if @can_create_volunteer_op and feature_active?(:volunteer_ops_create) %>
-        <%= link_to("Create a Volunteer Opportunity", new_organisation_volunteer_op_path(organisation_id: @organisation.id), {:class => 'btn btn-primary'}) %>
+        <%= link_to("Create a Volunteer Opportunity", new_organisation_volunteer_op_path(organisation_id: @organisation), {:class => 'btn btn-primary'}) %>
     <% end %>
     <% if current_user %>
-        <%= link_to "This is my organisation", user_path(pending_organisation_id: @organisation.id, id: current_user.id), {method: :put, class: 'btn btn-primary'} if @grabbable %>
+        <%= link_to "This is my organisation", user_path(pending_organisation_id: @organisation, id: current_user.id), {method: :put, class: 'btn btn-primary'} if @grabbable %>
     <% else %>
         <%= link_to "This is my organisation", new_user_session_path, {method: :put, 'data-signed_in' => current_user.present?, id: 'TIMO', class: 'btn btn-primary'} if @grabbable %>
     <% end %>

--- a/app/views/volunteer_ops/show.html.erb
+++ b/app/views/volunteer_ops/show.html.erb
@@ -9,7 +9,7 @@
 
   <p>
     <b>Organisation:</b>
-    <%= link_to @volunteer_op.organisation.name, organisation_path(@volunteer_op.organisation.id) %>
+    <%= link_to @volunteer_op.organisation.name, organisation_path(@volunteer_op.organisation) %>
   </p>
   <% if @editable %>
       <%= link_to("Edit", edit_volunteer_op_path(@volunteer_op.id), {:class => 'btn btn-primary'}) %>

--- a/db/migrate/20160421100439_add_slug_to_organisations.rb
+++ b/db/migrate/20160421100439_add_slug_to_organisations.rb
@@ -1,0 +1,15 @@
+class AddSlugToOrganisations < ActiveRecord::Migration
+  def up
+    add_column :organisations, :slug, :string
+    
+    add_index :organisations, :slug, unique: true
+    
+    Organisation.find_each(&:save!)
+  end
+  
+  def down
+    remove_index :organisations, :slug
+    
+    remove_column :organisations, :slug
+  end
+end

--- a/db/migrate/20160421100439_add_slug_to_organisations.rb
+++ b/db/migrate/20160421100439_add_slug_to_organisations.rb
@@ -4,7 +4,7 @@ class AddSlugToOrganisations < ActiveRecord::Migration
     
     add_index :organisations, :slug, unique: true
     
-    Organisation.find_each(&:save!)
+    Organisation.find_each(&:save)
   end
   
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160318085415) do
+ActiveRecord::Schema.define(version: 20160421100439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,7 +57,10 @@ ActiveRecord::Schema.define(version: 20160318085415) do
     t.datetime "deleted_at"
     t.string   "type",            default: "Organisation"
     t.boolean  "non_profit"
+    t.string   "slug"
   end
+
+  add_index "organisations", ["slug"], name: "index_organisations_on_slug", unique: true, using: :btree
 
   create_table "pages", force: :cascade do |t|
     t.string   "name"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -53,14 +53,14 @@ end
 
 Given /^I delete "(.*?)" charity$/ do |name|
   org = Organisation.find_by_name name
-  page.driver.submit :delete, "/organisations/#{org.id}", {}
+  page.driver.submit :delete, "/organisations/#{org.friendly_id}", {}
 end
 
 Then /^I should( not)? see an edit button for "(.*?)" charity$/ do |negate, name|
   expectation_method = negate ? :not_to : :to
   org = Organisation.find_by_name name
   expect(page).send(expectation_method,
-                    have_link('Edit', href: edit_organisation_path(org.id)))
+                    have_link('Edit', href: edit_organisation_path(org)))
 end
 
 Then /^I should( not)? see an edit button for "(.*?)" volunteer opportunity$/ do |negate, title|

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -2,7 +2,7 @@ Then(/^I should see an infowindow when I click on the map markers:$/) do |table|
   expect(page).to have_css('.measle', :count => table.raw.flatten.length)
   Organisation.where(name: table.raw.flatten)
         .pluck(:name, :description, :id, :slug)
-        .map {|name, desc, id, friendly_id| [name, smart_truncate(desc, 42), id, friendly_id]}
+        .map {|name, desc, id, frdly_id| [name, smart_truncate(desc, 42), id, frdly_id]}
         .each do |name, desc, id, friendly_id|
       expect(page).to have_css(".measle[data-id='#{id}']")
       icon =find(".measle[data-id='#{id}']")

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -1,6 +1,9 @@
 Then(/^I should see an infowindow when I click on the map markers:$/) do |table|
   expect(page).to have_css('.measle', :count => table.raw.flatten.length)
-  Organisation.where(name: table.raw.flatten).pluck(:name, :description, :id).map {|name, desc, id| [name, smart_truncate(desc, 42), id]}.each do |name, desc, id|
+  Organisation.where(name: table.raw.flatten)
+        .pluck(:name, :description, :id, :slug)
+        .map {|name, desc, id, friendly_id| [name, smart_truncate(desc, 42), id, friendly_id]}
+        .each do |name, desc, id, friendly_id|
       expect(page).to have_css(".measle[data-id='#{id}']")
       icon =find(".measle[data-id='#{id}']")
       click_twice icon
@@ -8,7 +11,7 @@ Then(/^I should see an infowindow when I click on the map markers:$/) do |table|
       expect(find('.arrow_box').text).to include(desc)
       expect(find('.arrow_box').text).to include(name)
       link = find('.arrow_box').find('a')[:href]
-      expect(link).to eql(organisation_path(id))
+      expect(link).to eql(organisation_path(friendly_id))
   end
 end
 def click_twice elt

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -90,7 +90,7 @@ Then /^I (visit|should be on) the (edit|show) page for the (.*?) (named|titled) 
                     only_path: true,
                     controller: object.pluralize.underscore,
                     action: action,
-                    id: record.id
+                    id: record
                 })
   case mode
     when 'visit' then visit url

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -13,7 +13,7 @@ describe OrganisationsController, :type => :controller do
     end
   end
 
-  describe "#build_map_markers" do
+  describe '#build_map_markers' do
     render_views
     let!(:org) { create :organisation }
     let(:org_relation){Organisation.all}
@@ -29,13 +29,13 @@ describe OrganisationsController, :type => :controller do
     end
   end
 
-  describe "GET search" do
+  describe 'GET search' do
 
     let(:category_params) do
       {
-        "what_id" => "",
-        "who_id"  => "",
-        "how_id"  => "",
+        'what_id' => '',
+        'who_id'  => '',
+        'how_id'  => '',
       }
     end
 
@@ -51,33 +51,33 @@ describe OrganisationsController, :type => :controller do
         allow(Category).to receive(:how_they_help) { Category.all }
       end
 
-      it "orders search results by most recent" do
+      it 'orders search results by most recent' do
         expect(Organisation).to receive(:order_by_most_recent).and_return(result)
         expect(result).to receive(:search_by_keyword).with('test').and_return(result)
         get :search, { q: 'test' }.merge(category_params)
         expect(assigns(:organisations)).to eq([double_organisation])
       end
 
-      it "sets up appropriate values for view vars: query_term, organisations and markers" do
+      it 'sets up appropriate values for view vars: query_term, organisations and markers' do
         expect(Organisation).to receive(:search_by_keyword).with('test').and_return(result)
         expect(result).to receive(:filter_by_categories).with(['1']).and_return(result)
-        get :search, { q: 'test' }.merge(category_params).merge("what_id" => "1")
+        get :search, { q: 'test' }.merge(category_params).merge('what_id' => '1')
         expect(assigns(:parsed_params).query_term).to eq 'test'
       end
 
-      it "handles lack of category gracefully" do
+      it 'handles lack of category gracefully' do
         expect(Organisation).to receive(:search_by_keyword).with('test').and_return(result)
         get :search, { q: 'test' }.merge(category_params)
         expect(assigns(:parsed_params).query_term).to eq 'test'
       end
 
-      it "handles lack of query term gracefully" do
-        expect(Organisation).to receive(:search_by_keyword).with("").and_return(result)
+      it 'handles lack of query term gracefully' do
+        expect(Organisation).to receive(:search_by_keyword).with('').and_return(result)
         get :search, category_params.merge({q: ''})
-        expect(assigns(:parsed_params).query_term).to eq("")
+        expect(assigns(:parsed_params).query_term).to eq('')
       end
 
-      it "handles lack of id gracefully" do
+      it 'handles lack of id gracefully' do
         expect(Organisation).to receive(:search_by_keyword).with('test').and_return(result)
         get :search, { q: 'test' }.merge(category_params)
         expect(assigns(:parsed_params).query_term).to eq 'test'
@@ -93,9 +93,9 @@ describe OrganisationsController, :type => :controller do
     end
 
     # TODO figure out how to make this less messy
-    it "assigns to flash.now but not flash when search returns no results" do
+    it 'assigns to flash.now but not flash when search returns no results' do
       expect(controller).to receive(:build_map_markers).and_return('my markers')
-      double_now_flash = double("FlashHash")
+      double_now_flash = double('FlashHash')
       result = Organisation.all
       expect(result).to receive(:empty?).and_return(true)
       expect(Organisation).to receive(:search_by_keyword).with('no results').and_return(result)
@@ -104,10 +104,10 @@ describe OrganisationsController, :type => :controller do
       expect_any_instance_of(ActionDispatch::Flash::FlashHash).to receive(:now).and_return double_now_flash
       expect_any_instance_of(ActionDispatch::Flash::FlashHash).not_to receive(:[]=)
       expect(double_now_flash).to receive(:[]=).with(:alert, SEARCH_NOT_FOUND)
-      get :search, { q: 'no results' }.merge(category_params).merge("what_id" => "1")
+      get :search, { q: 'no results' }.merge(category_params).merge('what_id' => '1')
     end
 
-    it "does not set up flash nor flash.now when search returns results" do
+    it 'does not set up flash nor flash.now when search returns results' do
       result = Organisation.all
       markers='my markers'
       expect(controller).to receive(:build_map_markers).and_return(markers)
@@ -115,14 +115,14 @@ describe OrganisationsController, :type => :controller do
       expect(Organisation).to receive(:search_by_keyword).with('some results').and_return(result)
       expect(result).to receive(:filter_by_categories).with(['1']).and_return(result)
       category = double('Category')
-      get :search, { q: 'some results' }.merge(category_params).merge("what_id" => "1")
+      get :search, { q: 'some results' }.merge(category_params).merge('what_id' => '1')
       expect(flash.now[:alert]).to be_nil
       expect(flash[:alert]).to be_nil
     end
   end
 
-  describe "GET index" do
-    it "assigns all organisations as @organisations" do
+  describe 'GET index' do
+    it 'assigns all organisations as @organisations' do
       result = Organisation.all
       markers='my markers'
       expect(controller).to receive(:build_map_markers).and_return(markers)
@@ -134,10 +134,10 @@ describe OrganisationsController, :type => :controller do
     end
   end
 
-  describe "GET show" do
+  describe 'GET show' do
     let(:real_org){create(:organisation)}
     before(:each) do
-      @user = double("User")
+      @user = double('User')
       allow(@user).to receive(:pending_org_admin?)
       allow(@user).to receive(:can_edit?)
       allow(@user).to receive(:can_delete?)
@@ -151,7 +151,7 @@ describe OrganisationsController, :type => :controller do
       expect(response).to render_template 'layouts/two_columns_with_map'
     end
 
-    it "assigns the requested organisation as @organisation and appropriate markers" do
+    it 'assigns the requested organisation as @organisation and appropriate markers' do
       markers='my markers'
       @org = real_org
       expect(controller).to receive(:build_map_markers).and_return(markers)
@@ -160,14 +160,14 @@ describe OrganisationsController, :type => :controller do
       expect(assigns(:markers)).to eq(markers)
     end
 
-    context "editable flag is assigned to match user permission" do
-      it "user with permission leads to editable flag true" do
+    context 'editable flag is assigned to match user permission' do
+      it 'user with permission leads to editable flag true' do
         expect(@user).to receive(:can_edit?).with(real_org).and_return(true)
         get :show, id: real_org.id.to_s
         expect(assigns(:editable)).to be(true)
       end
 
-      it "user without permission leads to editable flag false" do
+      it 'user without permission leads to editable flag false' do
         expect(@user).to receive(:can_edit?).with(real_org).and_return(true)
         get :show, id: real_org.id.to_s
         expect(assigns(:editable)).to be(true)
@@ -180,7 +180,7 @@ describe OrganisationsController, :type => :controller do
       end
     end
 
-    context "grabbable flag is assigned to match user permission" do
+    context 'grabbable flag is assigned to match user permission' do
       it 'assigns grabbable to true when user can request org superadmin status' do
         allow(@user).to receive(:can_edit?)
         expect(@user).to receive(:can_request_org_admin?).with(real_org).and_return(true)
@@ -226,16 +226,16 @@ describe OrganisationsController, :type => :controller do
     end
   end
 
-  describe "GET new" do
-    context "while signed in" do
+  describe 'GET new' do
+    context 'while signed in' do
       before(:each) do
-        user = double("User")
+        user = double('User')
         allow(request.env['warden']).to receive_messages :authenticate! => user
         allow(controller).to receive(:current_user).and_return(user)
         allow(Organisation).to receive(:new) { double_organisation }
       end
 
-      it "assigns a new organisation as @organisation" do
+      it 'assigns a new organisation as @organisation' do
         get :new
         expect(assigns(:organisation)).to be(double_organisation)
       end
@@ -246,227 +246,228 @@ describe OrganisationsController, :type => :controller do
       end
     end
 
-    context "while not signed in" do
-      it "redirects to sign-in" do
+    context 'while not signed in' do
+      it 'redirects to sign-in' do
         get :new
         expect(response).to redirect_to new_user_session_path
       end
     end
   end
 
-  describe "GET edit" do
+  describe 'GET edit' do
     let(:org) { create(:organisation) }
 
-    context "while signed in as user who can edit" do
+    context 'while signed in as user who can edit' do
       before(:each) do
-        user = double("User")
+        user = double('User')
         allow(user).to receive(:can_edit?) { true }
         allow(request.env['warden']).to receive_messages :authenticate! => user
         allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it "assigns the requested organisation as @organisation" do
+      it 'assigns the requested organisation as @organisation' do
         get :edit, id: org.id
         expect(assigns(:organisation)).to eq org
         expect(response).to render_template 'layouts/two_columns_with_map'
       end
     end
-    context "while signed in as user who cannot edit" do
+    context 'while signed in as user who cannot edit' do
       before(:each) do
-        user = double("User")
+        user = double('User')
         allow(user).to receive(:can_edit?) { false }
         allow(request.env['warden']).to receive_messages :authenticate! => user
         allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it "redirects to organisation view" do
+      it 'redirects to organisation view' do
         get :edit, id: org
         expect(response).to redirect_to organisation_url(org)
       end
     end
     #TODO: way to dry out these redirect specs?
-    context "while not signed in" do
-      it "redirects to sign-in" do
+    context 'while not signed in' do
+      it 'redirects to sign-in' do
         get :edit, :id => '37'
         expect(response).to redirect_to new_user_session_path
       end
     end
   end
 
-  describe "POST create", :helpers => :controllers do
-    context "while signed in as superadmin" do
+  describe 'POST create', :helpers => :controllers do
+    context 'while signed in as superadmin' do
       let!(:org) { build :organisation }
       before(:each) do
         expect(make_current_user_superadmin).to receive(:superadmin?).and_return true
       end
 
-      describe "with valid params" do
-        it "assigns a newly created organisation as @organisation" do
+      describe 'with valid params' do
+        it 'assigns a newly created organisation as @organisation' do
           allow(Organisation).to receive(:new) { org }
           post :create, :organisation => {'these' => 'params'}
           expect(assigns(:organisation)).to be org
         end
 
-        it "redirects to the created organisation" do
+        it 'redirects to the created organisation' do
           allow(Organisation).to receive(:new) { org }
-          post :create, :organisation => {name: "blah"}
+          post :create, :organisation => {name: 'blah'}
           expect(response).to redirect_to(organisation_url(org))
         end
       end
 
-      describe "with invalid params" do
+      describe 'with invalid params' do
         after(:each) { expect(response).to render_template 'two_columns_with_map' }
 
-        it "assigns a newly created but unsaved organisation as @organisation" do
+        it 'assigns a newly created but unsaved organisation as @organisation' do
           allow(Organisation).to receive(:new){ double_organisation(:save => false) }
           post :create, :organisation => {'these' => 'params'}
           expect(assigns(:organisation)).to be(double_organisation)
         end
 
-        it "re-renders the 'new' template" do
+        it 're-renders the "new" template' do
           allow(Organisation).to receive(:new) { double_organisation(:save => false) }
-          post :create, :organisation => {name: "great"}
-          expect(response).to render_template("new")
+          post :create, :organisation => {name: 'great'}
+          expect(response).to render_template('new')
         end
       end
     end
 
-    context "while not signed in" do
-      it "redirects to sign-in" do
+    context 'while not signed in' do
+      it 'redirects to sign-in' do
         allow(Organisation).to receive(:new).with({'these' => 'params'}) { double_organisation(:save => true) }
         post :create, :organisation => {'these' => 'params'}
         expect(response).to redirect_to new_user_session_path
       end
     end
 
-    context "while signed in as non-superadmin" do
+    context 'while signed in as non-superadmin' do
       before(:each) do
         expect(make_current_user_nonsuperadmin).to receive(:superadmin?).and_return(false)
       end
 
-      describe "with valid params" do
-        it "refuses to create a new organisation" do
+      describe 'with valid params' do
+        it 'refuses to create a new organisation' do
           # stubbing out Organisation to prevent new method from calling Gmaps APIs
           allow(Organisation).to receive(:new).with({'these' => 'params'}) { double_organisation(:save => true) }
           expect(Organisation).not_to receive :new
           post :create, :organisation => {'these' => 'params'}
         end
 
-        it "redirects to the organisations index" do
+        it 'redirects to the organisations index' do
           allow(Organisation).to receive(:new).with({'these' => 'params'}) { double_organisation(:save => true) }
           post :create, :organisation => {'these' => 'params'}
           expect(response).to redirect_to organisations_path
         end
 
-        it "assigns a flash refusal" do
+        it 'assigns a flash refusal' do
           allow(Organisation).to receive(:new).with({'these' => 'params'}) { double_organisation(:save => true) }
           post :create, :organisation => {'these' => 'params'}
-          expect(flash[:notice]).to eq("You don't have permission")
+          expect(flash[:notice]).to eq('You don\'t have permission')
         end
       end
       # not interested in invalid params
     end
   end
 
-  describe "PUT update" do
+  describe 'PUT update' do
     let(:org) { create :organisation }
     let(:all_orgs) { double }
-    context "while signed in as user who can edit" do
+    context 'while signed in as user who can edit' do
       before(:each) do
-        user = double("User")
+        user = double('User')
         allow(user).to receive(:can_edit?) { true }
         allow(request.env['warden']).to receive_messages :authenticate! => user
         allow(controller).to receive(:current_user).and_return(user)
         
       end
 
-      describe "with valid params" do
-        it "updates org for e.g. donation_info url" do
+      describe 'with valid params' do
+        it 'updates org for e.g. donation_info url' do
           expect(Organisation).to receive(:friendly) { all_orgs }
           expect(all_orgs).to receive(:find).with('37') { org }
           expect(org).to receive(:update_attributes_with_superadmin).with({'donation_info' => 'http://www.friendly.com/donate', 'superadmin_email_to_add' => nil})
           put :update, :id => '37', :organisation => {'donation_info' => 'http://www.friendly.com/donate'}
         end
 
-        it "assigns the requested organisation as @organisation" do
+        it 'assigns the requested organisation as @organisation' do
           allow(Organisation).to receive(:friendly) { all_orgs }
           allow(all_orgs).to receive(:find) { org }
-          put :update, :id => "1", :organisation => {'these' => 'params'}
+          put :update, :id => '1', :organisation => {'these' => 'params'}
           expect(assigns(:organisation)).to be(org)
         end
 
-        it "redirects to the organisation" do
+        it 'redirects to the organisation' do
           allow(Organisation).to receive(:friendly) { all_orgs }
           allow(all_orgs).to receive(:find) { org }
-          put :update, :id => "1", :organisation => {'these' => 'params'}
+          put :update, :id => '1', :organisation => {'these' => 'params'}
           expect(response).to redirect_to(organisation_url(org))
         end
       end
 
-      describe "with invalid params" do
+      describe 'with invalid params' do
+        let(:dbl_org) { double_organisation(update_attributes_with_superadmin: false) }
         before(:each) do 
           allow(Organisation).to receive(:friendly) { all_orgs }
-          allow(all_orgs).to receive(:find) { double_organisation(:update_attributes_with_superadmin => false) }
-          put :update, :id => "1", :organisation => {'these' => 'params'}
+          allow(all_orgs).to receive(:find) { dbl_org }
+          put :update, id: '1', organisation: {'these': 'params'}
         end
         after(:each) { expect(response).to render_template 'layouts/two_columns_with_map' }
 
-        it "assigns the organisation as @organisation" do
+        it 'assigns the organisation as @organisation' do
           expect(assigns(:organisation)).to be(double_organisation)
         end
 
-        it "re-renders the 'edit' template" do
-          expect(response).to render_template("edit")
+        it 're-renders the "edit" template' do
+          expect(response).to render_template('edit')
         end
       end
     end
 
-    context "while signed in as user who cannot edit" do
+    context 'while signed in as user who cannot edit' do
       before(:each) do
-        user = double("User")
+        user = double('User')
         allow(user).to receive(:can_edit?) { false }
         allow(request.env['warden']).to receive_messages :authenticate! => user
         allow(controller).to receive(:current_user).and_return(user)
       end
 
-      describe "with existing organisation" do
-        it "does not update the requested organisation" do
+      describe 'with existing organisation' do
+        it 'does not update the requested organisation' do
           org = double_organisation(:id => 37)
           expect(Organisation).to receive(:friendly) { all_orgs }
           expect(all_orgs).to receive(:find).with("#{org.id}") { org }
           expect(org).not_to receive(:update_attributes)
           put :update, :id => "#{org.id}", :organisation => {'these' => 'params'}
           expect(response).to redirect_to(organisation_url("#{org.id}"))
-          expect(flash[:notice]).to eq("You don't have permission")
+          expect(flash[:notice]).to eq('You don\'t have permission')
         end
       end
 
-      describe "with non-existent organisation" do
-        it "does not update the requested organisation" do
+      describe 'with non-existent organisation' do
+        it 'does not update the requested organisation' do
           expect(Organisation).to receive(:friendly) { all_orgs }
-          expect(all_orgs).to receive(:find).with("9999") { nil }
-          put :update, :id => "9999", :organisation => {'these' => 'params'}
-          expect(response).to redirect_to(organisation_url("9999"))
-          expect(flash[:notice]).to eq("You don't have permission")
+          expect(all_orgs).to receive(:find).with('9999') { nil }
+          put :update, :id => '9999', :organisation => {'these' => 'params'}
+          expect(response).to redirect_to(organisation_url('9999'))
+          expect(flash[:notice]).to eq('You don\'t have permission')
         end
       end
     end
 
-    context "while not signed in" do
-      it "redirects to sign-in" do
-        put :update, :id => "1", :organisation => {'these' => 'params'}
+    context 'while not signed in' do
+      it 'redirects to sign-in' do
+        put :update, :id => '1', :organisation => {'these' => 'params'}
         expect(response).to redirect_to new_user_session_path
       end
     end
   end
 
-  describe "DELETE destroy" do
+  describe 'DELETE destroy' do
     let(:all_orgs) { double }
-    context "while signed in as superadmin", :helpers => :controllers do
+    context 'while signed in as superadmin', :helpers => :controllers do
       before(:each) do
         make_current_user_superadmin
       end
-      it "destroys the requested organisation and redirect to organisation list" do
+      it 'destroys the requested organisation and redirect to organisation list' do
         expect(Organisation).to receive(:friendly) { all_orgs }
         expect(all_orgs).to receive(:find).with('37') { double_organisation }
         expect(double_organisation).to receive(:destroy)
@@ -474,11 +475,11 @@ describe OrganisationsController, :type => :controller do
         expect(response).to redirect_to(organisations_url)
       end
     end
-    context "while signed in as non-superadmin", :helpers => :controllers do
+    context 'while signed in as non-superadmin', :helpers => :controllers do
       before(:each) do
         make_current_user_nonsuperadmin
       end
-      it "does not destroy the requested organisation but redirects to organisation home page" do
+      it 'does not destroy the requested organisation but redirects to organisation home page' do
         double = double_organisation
         expect(Organisation).not_to receive(:find).with('37') { double }
         expect(double).not_to receive(:destroy)
@@ -486,20 +487,20 @@ describe OrganisationsController, :type => :controller do
         expect(response).to redirect_to(organisation_url('37'))
       end
     end
-    context "while not signed in" do
-      it "redirects to sign-in" do
+    context 'while not signed in' do
+      it 'redirects to sign-in' do
         delete :destroy, :id => '37'
         expect(response).to redirect_to new_user_session_path
       end
     end
   end
-  describe ".permit" do 
-    it "returns the cleaned params" do
+  describe '.permit' do 
+    it 'returns the cleaned params' do
       organisation_params = { organisation: {name: 'Happy Friends', description: 'Do nice things', address: '22 Pinner Road', 
                              postcode: '12345', email: 'happy@annoting.com', website: 'www.happyplace.com', 
                              telephone: '123-456-7890', donation_info: 'www.giveusmoney.com',
                              publish_address: true, publish_phone: true, publish_email: true, 
-                             category_organisations_attributes: {'1' => {"_destroy" => "1", "id" => "1", "category_id" => "5"}}
+                             category_organisations_attributes: {'1' => {'_destroy' => '1', 'id' => '1', 'category_id' => '5'}}
                              }}
       params = ActionController::Parameters.new.merge(organisation_params)
       permitted_params = OrganisationsController::OrganisationParams.build(params)
@@ -507,7 +508,7 @@ describe OrganisationsController, :type => :controller do
                                       postcode: '12345', email: 'happy@annoting.com', website: 'www.happyplace.com', 
                                       telephone: '123-456-7890', donation_info: 'www.giveusmoney.com',
                                       publish_address: true, publish_phone: true, publish_email: true,
-                                      category_organisations_attributes: {'1' => {"_destroy" => "1", "id" => "1", "category_id" => "5"}}
+                                      category_organisations_attributes: {'1' => {'_destroy' => '1', 'id' => '1', 'category_id' => '5'}}
                                       }.with_indifferent_access)
       #attr_accessible :name, :description, :address, :postcode, :email, :website, :telephone, :donation_info, :publish_address, :publish_phone, :publish_email, :category_organisations_attributes
     end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -20,7 +20,7 @@ describe OrganisationsController, :type => :controller do
     subject { JSON.parse(controller.send(:build_map_markers, org_relation)).first }
     it { expect(subject['lat']).to eq org.latitude }
     it { expect(subject['lng']).to eq org.longitude }
-    it { expect(subject['infowindow']).to include org.id.to_s }
+    it { expect(subject['infowindow']).to include org.friendly_id }
     it { expect(subject['infowindow']).to include org.name }
     it { expect(subject['infowindow']).to include org.description }
     context 'markers without coords omitted' do
@@ -280,7 +280,7 @@ describe OrganisationsController, :type => :controller do
       end
 
       it "redirects to organisation view" do
-        get :edit, id: org.id
+        get :edit, id: org
         expect(response).to redirect_to organisation_url(org)
       end
     end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -293,7 +293,7 @@ describe OrganisationsController, :type => :controller do
     end
   end
 
-  describe 'POST create', :helpers => :controllers do
+  describe 'POST create', helpers: :controllers do
     context 'while signed in as superadmin' do
       let!(:org) { build :organisation }
       before(:each) do
@@ -309,7 +309,7 @@ describe OrganisationsController, :type => :controller do
 
         it 'redirects to the created organisation' do
           allow(Organisation).to receive(:new) { org }
-          post :create, :organisation => {name: 'blah'}
+          post :create, organisation: {name: 'blah'}
           expect(response).to redirect_to(organisation_url(org))
         end
       end
@@ -325,7 +325,7 @@ describe OrganisationsController, :type => :controller do
 
         it 're-renders the "new" template' do
           allow(Organisation).to receive(:new) { double_organisation(:save => false) }
-          post :create, :organisation => {name: 'great'}
+          post :create, organisation: {name: 'great'}
           expect(response).to render_template('new')
         end
       end
@@ -391,14 +391,14 @@ describe OrganisationsController, :type => :controller do
         it 'assigns the requested organisation as @organisation' do
           allow(Organisation).to receive(:friendly) { all_orgs }
           allow(all_orgs).to receive(:find) { org }
-          put :update, :id => '1', :organisation => {'these' => 'params'}
+          put :update, id: '1', organisation: {'these': 'params'}
           expect(assigns(:organisation)).to be(org)
         end
 
         it 'redirects to the organisation' do
           allow(Organisation).to receive(:friendly) { all_orgs }
           allow(all_orgs).to receive(:find) { org }
-          put :update, :id => '1', :organisation => {'these' => 'params'}
+          put :update, id: '1', organisation: {'these': 'params'}
           expect(response).to redirect_to(organisation_url(org))
         end
       end
@@ -446,7 +446,7 @@ describe OrganisationsController, :type => :controller do
         it 'does not update the requested organisation' do
           expect(Organisation).to receive(:friendly) { all_orgs }
           expect(all_orgs).to receive(:find).with('9999') { nil }
-          put :update, :id => '9999', :organisation => {'these' => 'params'}
+          put :update, id: '9999', organisation: {'these': 'params'}
           expect(response).to redirect_to(organisation_url('9999'))
           expect(flash[:notice]).to eq('You don\'t have permission')
         end
@@ -455,7 +455,7 @@ describe OrganisationsController, :type => :controller do
 
     context 'while not signed in' do
       it 'redirects to sign-in' do
-        put :update, :id => '1', :organisation => {'these' => 'params'}
+        put :update, id: '1', organisation: {'these': 'params'}
         expect(response).to redirect_to new_user_session_path
       end
     end
@@ -463,7 +463,7 @@ describe OrganisationsController, :type => :controller do
 
   describe 'DELETE destroy' do
     let(:all_orgs) { double }
-    context 'while signed in as superadmin', :helpers => :controllers do
+    context 'while signed in as superadmin', helpers: :controllers do
       before(:each) do
         make_current_user_superadmin
       end
@@ -471,11 +471,11 @@ describe OrganisationsController, :type => :controller do
         expect(Organisation).to receive(:friendly) { all_orgs }
         expect(all_orgs).to receive(:find).with('37') { double_organisation }
         expect(double_organisation).to receive(:destroy)
-        delete :destroy, :id => '37'
+        delete :destroy, id: '37'
         expect(response).to redirect_to(organisations_url)
       end
     end
-    context 'while signed in as non-superadmin', :helpers => :controllers do
+    context 'while signed in as non-superadmin', helpers: :controllers do
       before(:each) do
         make_current_user_nonsuperadmin
       end
@@ -496,19 +496,35 @@ describe OrganisationsController, :type => :controller do
   end
   describe '.permit' do 
     it 'returns the cleaned params' do
-      organisation_params = { organisation: {name: 'Happy Friends', description: 'Do nice things', address: '22 Pinner Road', 
-                             postcode: '12345', email: 'happy@annoting.com', website: 'www.happyplace.com', 
-                             telephone: '123-456-7890', donation_info: 'www.giveusmoney.com',
-                             publish_address: true, publish_phone: true, publish_email: true, 
-                             category_organisations_attributes: {'1' => {'_destroy' => '1', 'id' => '1', 'category_id' => '5'}}
-                             }}
+      organisation_params = { organisation: {
+                                name: 'Happy Friends', 
+                                description: 'Do nice things', 
+                                address: '22 Pinner Road', 
+                                postcode: '12345', 
+                                email: 'happy@annoting.com', 
+                                website: 'www.happyplace.com', 
+                                telephone: '123-456-7890', 
+                                donation_info: 'www.giveusmoney.com',
+                                publish_address: true, 
+                                publish_phone: true, 
+                                publish_email: true, 
+                                category_organisations_attributes: {
+                                  '1' => {'_destroy' => '1', 'id' => '1', 'category_id' => '5'}}
+                            }}
       params = ActionController::Parameters.new.merge(organisation_params)
       permitted_params = OrganisationsController::OrganisationParams.build(params)
-      expect(permitted_params).to eq({name: 'Happy Friends', description: 'Do nice things', address: '22 Pinner Road', 
-                                      postcode: '12345', email: 'happy@annoting.com', website: 'www.happyplace.com', 
-                                      telephone: '123-456-7890', donation_info: 'www.giveusmoney.com',
-                                      publish_address: true, publish_phone: true, publish_email: true,
-                                      category_organisations_attributes: {'1' => {'_destroy' => '1', 'id' => '1', 'category_id' => '5'}}
+      expect(permitted_params).to eq({name: 'Happy Friends', 
+                                      description: 'Do nice things', 
+                                      address: '22 Pinner Road', 
+                                      postcode: '12345', email: 'happy@annoting.com', 
+                                      website: 'www.happyplace.com', 
+                                      telephone: '123-456-7890', 
+                                      donation_info: 'www.giveusmoney.com',
+                                      publish_address: true, 
+                                      publish_phone: true, 
+                                      publish_email: true,
+                                      category_organisations_attributes: {
+                                        '1' => {'_destroy' => '1', 'id' => '1', 'category_id' => '5'}}
                                       }.with_indifferent_access)
       #attr_accessible :name, :description, :address, :postcode, :email, :website, :telephone, :donation_info, :publish_address, :publish_phone, :publish_email, :category_organisations_attributes
     end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -26,7 +26,7 @@ describe SessionsController, :type => :controller do
       usr = FactoryGirl.build(:user_stubbed_organisation, {:email => 'example@example.com', :password => 'pppppppp'})
       allow(controller).to receive_messages :session => {previous_url: "/"}
       post :create, 'user' => {'email' => 'example@example.com', 'password' => 'pppppppp'}
-      expect(response).to redirect_to organisation_path(usr.organisation.id)
+      expect(response).to redirect_to organisation_path(usr.organisation)
     end
 
   end

--- a/spec/requests/volunteer_ops_spec.rb
+++ b/spec/requests/volunteer_ops_spec.rb
@@ -12,14 +12,14 @@ describe 'VolunteerOps', :type => :request, :helpers => :requests do
       org_admin = org_owner
       login(org_admin)
       expect {
-        post organisation_volunteer_ops_path(org_admin.organisation.id), params
+        post organisation_volunteer_ops_path(org_admin.organisation), params
       }.to change(VolunteerOp, :count).by(1)
     end
 
     it 'the new VolunteerOp is associated with the requested organisation' do
       org_admin = org_owner
       login(org_admin)
-      post organisation_volunteer_ops_path(org_admin.organisation.id), params
+      post organisation_volunteer_ops_path(org_admin.organisation), params
       op = VolunteerOp.last
       expect(op.organisation).to eq org_admin.organisation
     end

--- a/spec/requests/volunteer_ops_spec.rb
+++ b/spec/requests/volunteer_ops_spec.rb
@@ -12,14 +12,14 @@ describe 'VolunteerOps', :type => :request, :helpers => :requests do
       org_admin = org_owner
       login(org_admin)
       expect {
-        post organisation_volunteer_ops_path(org_admin.organisation), params
+        post organisation_volunteer_ops_path(org_admin.organisation.id), params
       }.to change(VolunteerOp, :count).by(1)
     end
 
     it 'the new VolunteerOp is associated with the requested organisation' do
       org_admin = org_owner
       login(org_admin)
-      post organisation_volunteer_ops_path(org_admin.organisation), params
+      post organisation_volunteer_ops_path(org_admin.organisation.id), params
       op = VolunteerOp.last
       expect(op.organisation).to eq org_admin.organisation
     end
@@ -27,14 +27,14 @@ describe 'VolunteerOps', :type => :request, :helpers => :requests do
     it 'does not work for non-org-owners' do
       login(non_org_owner)
       expect {
-        post organisation_volunteer_ops_path(org_owner.organisation), params
+        post organisation_volunteer_ops_path(org_owner.organisation.id), params
       }.to change(VolunteerOp, :count).by(0)
     end
 
     it 'does work for superadmins' do
       login(superadmin)
       expect{
-        post organisation_volunteer_ops_path(org_owner.organisation), params
+        post organisation_volunteer_ops_path(org_owner.organisation.id), params
       }.to change(VolunteerOp, :count).by(1)
     end
   end

--- a/spec/views/volunteer_ops/show.html.erb_spec.rb
+++ b/spec/views/volunteer_ops/show.html.erb_spec.rb
@@ -35,7 +35,7 @@ describe "volunteer_ops/show", :type => :view do
     expect(rendered).
       to have_xpath(
                     "//a[contains(.,'#{op.organisation.name}')" +
-                    " and @href=\"#{organisation_path(op.organisation.id)}\"]")
+                    " and @href=\"#{organisation_path(op.organisation)}\"]")
   end
   context 'with the right to edit' do
     it 'renders an edit button' do


### PR DESCRIPTION
Second attempt on - https://www.pivotaltracker.com/story/show/89294872.

@tansaku: I followed your advice. I cleared up everything, made small steps and assured that :slug column would be filled with content with the migration. 

Unfortunately, it turned out to be impossible to make just small changes. Just adding $extend FriendlyId to BaseOrganisation model made 6 specs fail. After fixing them 56 cucumber tests were failing. To fix them all I needed in fact to implement friendly_id in the whole app (at least everywhere, where the tests showed me to). I had also to update some steps in cucumber and specs (especially I had to stub new :friendly method).

Now I'm left with 5 failing cucumber tests, which are tricky for me, because they appear in part of app, which authenticates the user (with Devise) and in some point redirects the flow to the page with id instead of friendly_id. 

It seems that friendly_id has quite long tentacles embracing the whole app.