### PR TITLE
Remove assests log from development log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development do
   #gem 'debugger', '~> 1.6.8'
   gem "letter_opener"
   gem 'railroady'
+  gem 'quiet_assets'
 end
 
 group :test do
@@ -48,7 +49,6 @@ group :test do
   gem 'selenium-client'
   gem 'coveralls', require: false
   gem 'shoulda'
-  gem 'rspec-activemodel-mocks'
   gem 'vcr'
   gem 'puffing-billy'
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,8 @@ GEM
       eventmachine_httpserver
       http_parser.rb (~> 0.6.0)
       multi_json
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -399,6 +401,7 @@ DEPENDENCIES
   phantomjs
   poltergeist
   puffing-billy
+  quiet_assets
   rack_session_access
   railroady
   rails (~> 4.2.0)


### PR DESCRIPTION
To help debugging and log check during development by excluding assets log I added `quiet_assets` gem
- check more on 'https://github.com/evrone/quiet_assets'