### PR TITLE
generate friendly_id without updating 'update_at' field

### DIFF
--- a/app/services/without_timestamps.rb
+++ b/app/services/without_timestamps.rb
@@ -1,0 +1,11 @@
+module WithoutTimestamps
+  def self.run
+    old = ActiveRecord::Base.record_timestamps
+    ActiveRecord::Base.record_timestamps = false
+    begin
+      yield
+    ensure
+      ActiveRecord::Base.record_timestamps = old
+    end
+  end
+end

--- a/db/migrate/20160421100439_add_slug_to_organisations.rb
+++ b/db/migrate/20160421100439_add_slug_to_organisations.rb
@@ -3,8 +3,6 @@ class AddSlugToOrganisations < ActiveRecord::Migration
     add_column :organisations, :slug, :string
     
     add_index :organisations, :slug, unique: true
-    
-    Organisation.find_each(&:save)
   end
   
   def down

--- a/lib/tasks/generate_friendly_id.rake
+++ b/lib/tasks/generate_friendly_id.rake
@@ -1,0 +1,14 @@
+begin
+  namespace :db do
+    desc 'Generate friendly id for Organisations records'
+    task :friendly_id => :environment do
+      Logger.new(STDOUT).info 'Start friendly_id generation'
+      Organisation.find_each do |org|
+        WithoutTimestamps.run do
+          org.save
+        end
+      end
+      Logger.new(STDOUT).info 'Friendly_id generation finished'
+    end
+  end
+end

--- a/spec/services/without_timestamps_spec.rb
+++ b/spec/services/without_timestamps_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe WithoutTimestamps do
+
+  it 'save model without updating timestamps' do
+    org = FactoryGirl.build(:organisation)
+    WithoutTimestamps.run do
+      org.save
+    end
+    expect(org.created_at).to eq(nil)
+    expect(org.updated_at).to eq(nil)
+  end
+
+  it 'update model without updating timestamps' do
+    org = FactoryGirl.create(:organisation, name: 'test org')
+    org.name = 'new org name'
+    expect do
+      WithoutTimestamps.run do
+      org.save
+      end
+    end.not_to change{org.updated_at}
+  end
+
+end


### PR DESCRIPTION
- task to generate friendly_id: rake db:friendly_id

Note: I deleted the friendly_id generation from the migration file.