### PR TITLE
Little spike into rearranging google subpage results

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,20 +8,26 @@
 
   <url>
     <loc>https://www.harrowcn.org.uk/</loc>
-  </url>
-  <url>
-    <loc>https://www.harrowcn.org.uk/about</loc>
-  </url>
-  <url>
-    <loc>https://www.harrowcn.org.uk/contact</loc>
-  </url>
-  <url>
-    <loc>https://www.harrowcn.org.uk/organisations</loc>
+    <priority>1.00</priority>
   </url>
   <url>
     <loc>https://www.harrowcn.org.uk/volunteer_ops</loc>
+    <priority>0.90</priority>
+  </url>
+  <url>
+    <loc>https://www.harrowcn.org.uk/about</loc>
+    <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://www.harrowcn.org.uk/organisations</loc>
+    <priority>0.70</priority>
+  </url>
+  <url>
+    <loc>https://www.harrowcn.org.uk/contact</loc>
+    <priority>0.60</priority>
   </url>
   <url>
     <loc>https://www.harrowcn.org.uk/disclaimer</loc>
+    <priority>0.50</priority>
   </url>
 </urlset>


### PR DESCRIPTION
It's an answer to the task - https://www.pivotaltracker.com/story/show/111677414.

1. Basically, what I've found out is that Google doesn't let to set "subpage results", which they call "sitelinks", manually.

2. Exact criteria for Google algorythms in this area are not public. Nevertheless, there are some sources saying what might be done to have this working (without certainty).

3. Here I've found information that one of elements that may have influence on algorythm is sitemap.xml file - http://bit.ly/1Oc5HXZ. Because of that, I've added <priority> tag to the sitemap.xml. I understood that you would like to have as first two sitelink "Volunteer" and "About Us", so I gave them the highest priority (after root).

4. Moreover, I've changed the order of the urls in the sitemap.xml to match the priority.

5. Also, I've found that it is posible to demote sitelinks from the results. To do that it's necessary to use the Search Dashboard - as I understand it is available to you, @tansaku, as the webmaster. Here you'll find instructions on how to do that exactly:
- https://support.google.com/webmasters/answer/47334?hl=en 
- http://www.gsqi.com/marketing-blog/how-to-demote-sitelinks-google-webmaster-tools/

6. I was thinking about changing something in the partial views/layouts/_header.html.erb, but I didn't find any point that could be improved. 
I considered hints given here (https://support.google.com/webmasters/answer/47334?hl=en) and here (https://www.hochmanconsultants.com/how-to-get-google-sitelinks/).
