### PR TITLE
Fixing db:setup

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name":"LocalSupport",
   "scripts":{
-    "postdeploy": "bundle exec rake db:setup"
+    "postdeploy": "bundle exec rake db:migrate db:setup"
   },
   "env":{
     "BUILDPACK_URL":{

--- a/clean-ubuntu-install-2.sh
+++ b/clean-ubuntu-install-2.sh
@@ -71,6 +71,7 @@ if [[ $@ != *no_db_seed* ]]; then
   bundle exec rake db:seed || { error "seed DB"; return 1; }
   bundle exec rake db:cat_org_import || { error "add org to DB"; return 1; }
   bundle exec rake db:pages || { error "add pages to DB"; return 1; }
+  bundle exec rake db:import:emails[db/emails.csv] || { error "add emails to DB"; return 1; }
 fi
 
 # Prepare test database

--- a/lib/tasks/custom_setup.rake
+++ b/lib/tasks/custom_setup.rake
@@ -4,7 +4,6 @@ begin
     desc 'Setup project data'
     task :setup => :environment do
 
-      Rake::Task['db:migrate'].invoke
       Rake::Task['db:categories'].invoke
       Rake::Task['db:seed'].invoke
       Rake::Task['db:cat_org_import'].invoke

--- a/ubuntu-install.sh
+++ b/ubuntu-install.sh
@@ -76,6 +76,7 @@ if [[ $@ != *no_db_seed* ]]; then
   bundle exec rake db:seed || { error "seed DB"; return 1; }
   bundle exec rake db:cat_org_import || { error "add org to DB"; return 1; }
   bundle exec rake db:pages || { error "add pages to DB"; return 1; }
+  bundle exec rake db:import:emails[db/emails.csv] || { error "add emails to DB"; return 1; }
 fi
 
 # Prepare test database


### PR DESCRIPTION
PT - https://www.pivotaltracker.com/story/show/119360297.

By removing db:migrate from db:setup I fixed the issue of NoMethodError (no method 'slug' for Organisation), which was being thrown while seeding. The issue was noticed by @marouen on localsupport Slack channel. 

It seems that when db:migrate and db:seed were run through one rake task, the slug method (which should match slug column in db, created in migration) wasn't seen by the process. If the tasks are run separately, everything runs normally.