### PR TITLE
Fix rake test with coveralls task

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -149,3 +149,8 @@ end
 After('@time_travel') do
   Timecop.return
 end
+
+After do |s| 
+  # Tell Cucumber to quit after this scenario is done - if it failed.
+  Cucumber.wants_to_quit = true if s.failed?
+end


### PR DESCRIPTION
@tansaku I added a hook to exit at first error which keeps the state of task as failed and allow to have a faster feedback for the CI checks.