### PR TITLE
Adds rake task for friendly id reload

### DIFF
--- a/lib/tasks/generate_friendly_id.rake
+++ b/lib/tasks/generate_friendly_id.rake
@@ -5,6 +5,7 @@ begin
       Logger.new(STDOUT).info 'Start friendly_id generation'
       Organisation.find_each do |org|
         WithoutTimestamps.run do
+          org.slug = nil
           org.save
         end
       end


### PR DESCRIPTION
I've found out that new slugs won't be generated, unless they will be reset (set to nil and saved again).

To do that, I've modified the rake db:friendly_id task. Now, it's setting org.slug to nil before saving it.