### PR TITLE
Fix doit vol op import tasks[fixes #127384707]

### DIFF
--- a/app/controllers/volunteer_ops_controller.rb
+++ b/app/controllers/volunteer_ops_controller.rb
@@ -1,6 +1,8 @@
 class VolunteerOpsController < ApplicationController
   layout 'two_columns_with_map'
-  before_action :authorize, :except => [:search, :show, :index]
+  before_action :authorize, except: [:search, :show, :index]
+  before_action :set_organisation, only: [:new, :create]
+  
 
   def search
     @query = params[:q]
@@ -31,13 +33,12 @@ class VolunteerOpsController < ApplicationController
   end
 
   def create
-    org = Organisation.friendly.find(params[:organisation_id])
-    params[:volunteer_op][:organisation_id] = org.id
+    params[:volunteer_op][:organisation_id] = @organisation.id
     @volunteer_op = VolunteerOp.new(volunteer_op_params)
     if @volunteer_op.save
       redirect_to @volunteer_op, notice: 'Volunteer op was successfully created.'
     else
-      render action: 'new'
+      render :new
     end
   end
 
@@ -72,6 +73,8 @@ class VolunteerOpsController < ApplicationController
       :description,
       :title,
       :organisation_id,
+      :address,
+      :postcode
     )
   end
 
@@ -93,5 +96,9 @@ class VolunteerOpsController < ApplicationController
     else
       current_user.organisation == VolunteerOp.find(params[:id]).organisation if current_user.present? && current_user.organisation.present?
     end
+  end
+  
+  def set_organisation
+    @organisation = Organisation.friendly.find(params[:organisation_id])
   end
 end

--- a/app/models/volunteer_op.rb
+++ b/app/models/volunteer_op.rb
@@ -3,9 +3,10 @@ class VolunteerOp < ActiveRecord::Base
   validates :title, :description, presence: true
   validates :organisation_id, presence: true, if: "source == 'local'"
   belongs_to :organisation
-  
-   geocoded_by :full_address
-   after_validation :geocode, if: :address_complete? 
+
+  geocoded_by :full_address
+  after_validation :geocode, if: :address_complete?
+  after_validation :clear_lat_lng, if: "source == 'local'"
 
   scope :order_by_most_recent, -> { order('updated_at DESC') }
   scope :local_only, -> { where(source: 'local') }
@@ -41,9 +42,17 @@ class VolunteerOp < ActiveRecord::Base
   def self.contains_title?(text)
     arel_table[:title].matches(text)
   end
-  
+
   def address_complete?
     address.present? && postcode.present?
-  end 
-  
+  end
+
+  private
+
+  def clear_lat_lng
+    return if address_complete?
+    self.longitude = nil
+    self.latitude = nil
+  end
+
 end

--- a/app/models/volunteer_op.rb
+++ b/app/models/volunteer_op.rb
@@ -3,10 +3,18 @@ class VolunteerOp < ActiveRecord::Base
   validates :title, :description, presence: true
   validates :organisation_id, presence: true, if: "source == 'local'"
   belongs_to :organisation
+  
+   geocoded_by :full_address
+   after_validation :geocode, if: :address_complete? 
+   after_validation :clear_lat_lng
 
   scope :order_by_most_recent, -> { order('updated_at DESC') }
   scope :local_only, -> { where(source: 'local') }
 
+
+  def full_address
+    "#{self.address}, #{self.postcode}"
+  end
   def organisation_name
     return organisation.name if source == 'local'
     doit_org_name
@@ -33,5 +41,17 @@ class VolunteerOp < ActiveRecord::Base
 
   def self.contains_title?(text)
     arel_table[:title].matches(text)
+  end
+  
+  def address_complete?
+    address.present? && postcode.present?
+  end 
+  
+  private
+  
+  def clear_lat_lng
+    return if address_complete?
+    self.longitude = nil
+    self.latitude = nil
   end
 end

--- a/app/models/volunteer_op.rb
+++ b/app/models/volunteer_op.rb
@@ -6,7 +6,6 @@ class VolunteerOp < ActiveRecord::Base
   
    geocoded_by :full_address
    after_validation :geocode, if: :address_complete? 
-   after_validation :clear_lat_lng
 
   scope :order_by_most_recent, -> { order('updated_at DESC') }
   scope :local_only, -> { where(source: 'local') }
@@ -47,11 +46,4 @@ class VolunteerOp < ActiveRecord::Base
     address.present? && postcode.present?
   end 
   
-  private
-  
-  def clear_lat_lng
-    return if address_complete?
-    self.longitude = nil
-    self.latitude = nil
-  end
 end

--- a/app/services/import_do_it_volunteer_opportunities.rb
+++ b/app/services/import_do_it_volunteer_opportunities.rb
@@ -27,8 +27,15 @@ class ImportDoItVolunteerOpportunities
   def process_doit_json_page(response)
     return nil unless has_content?(response)
     opportunities = JSON.parse(response.body)['data']['items']
-    persist_doit_vol_ops(opportunities)
+    valid_opportunities = get_valid_oppurtunities(opportunities)
+    persist_doit_vol_ops(valid_opportunities)
     JSON.parse(response.body)['links'].fetch('next', 'href' => nil)['href']
+  end
+
+  def get_valid_oppurtunities(opportunities)
+    opportunities.select do |op|
+      op['lat'] && op['lng']
+    end
   end
 
   def persist_doit_vol_ops(opportunities)

--- a/app/views/volunteer_ops/_form.html.erb
+++ b/app/views/volunteer_ops/_form.html.erb
@@ -17,6 +17,16 @@
     <%= f.label :description , :style => "margin-top: 16px;" %>
     <%= f.text_area :description, :class => "wide_form" %>
   </div>
+  <div class="field">
+    <%= f.label :address , 'Address', :style => "margin-top: 16px;" %>
+    <%= f.text_field :address, :class => "wide_form",
+                    placeholder: "#{@organisation.address}" %>    
+  </div>
+  <div class="field">
+    <%= f.label :postcode , 'Postcode', :style => "margin-top: 16px;" %>
+    <%= f.text_field :postcode, :class => "wide_form",
+                    placeholder: "#{@organisation.postcode}"%>    
+  </div>    
   <div class="actions" style="margin-top: 16px;">
     <%= f.submit button_text(@volunteer_op), class: 'btn btn-primary' %>
   </div>

--- a/app/views/volunteer_ops/show.html.erb
+++ b/app/views/volunteer_ops/show.html.erb
@@ -6,7 +6,14 @@
   <p>
     <%= simple_format auto_link @volunteer_op.description %>
   </p>
-
+  
+  <% if @volunteer_op.address_complete? %>
+    <p>
+      <b>Volunteer opportunity location:</b>
+      <%= "#{ @volunteer_op.address }, #{ @volunteer_op.postcode }" %>
+    </p>
+  <% end %>
+  
   <p>
     <b>Organisation:</b>
     <%= link_to @volunteer_op.organisation.name, organisation_path(@volunteer_op.organisation) %>

--- a/db/migrate/20160628192920_add_address_to_volunteer_ops.rb
+++ b/db/migrate/20160628192920_add_address_to_volunteer_ops.rb
@@ -1,0 +1,6 @@
+class AddAddressToVolunteerOps < ActiveRecord::Migration
+  def change
+    add_column :volunteer_ops, :address, :string
+    add_column :volunteer_ops, :postcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160525151544) do
+ActiveRecord::Schema.define(version: 20160628192920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,8 @@ ActiveRecord::Schema.define(version: 20160525151544) do
     t.float    "longitude"
     t.float    "latitude"
     t.datetime "deleted_at"
+    t.string   "address"
+    t.string   "postcode"
   end
 
   add_index "volunteer_ops", ["deleted_at"], name: "index_volunteer_ops_on_deleted_at", using: :btree

--- a/features/admin/admin_edit_volunteer_op.feature
+++ b/features/admin/admin_edit_volunteer_op.feature
@@ -36,3 +36,11 @@ Scenario: Super Admin successfully changes the description of an opportunity
   Given I am signed in as a superadmin
   When I update "Litter Box Scooper" volunteer op description to be "Clean up cat mess"
   Then I should see "Clean up cat mess"
+
+@vcr 
+Scenario: Super Admin successfully changes volunteer opportunity location
+  Given I am signed in as a superadmin
+  When I visit the show page for the volunteer_op titled "Litter Box Scooper"
+  And I click "Edit"
+  And I set new volunteer opportunity location to "Station Rd", "HA8 7BD"
+  Then I should see "Station Rd, HA8 7BD"

--- a/features/devops/import_doit.feature
+++ b/features/devops/import_doit.feature
@@ -7,6 +7,7 @@ Feature: Importing DoIt Volunteer Ops
   Scenario: Check 3 miles
     Given I run the import doit service with a radius of 3 miles
     Then there should be 182 doit volunteer ops stored
+    And all imported volunteer ops have latitude and longitude coordinates
 
   Scenario: Check import removes ops that are no longer on doit
     Given there is a doit volunteer op named "no longer on doit"

--- a/features/req_cache/get_maps.googleapis.com_1f3838186c3919b1c73630d22cb9df6f5ebf6111.yml
+++ b/features/req_cache/get_maps.googleapis.com_1f3838186c3919b1c73630d22cb9df6f5ebf6111.yml
@@ -1,0 +1,21 @@
+---
+:scope: 
+:url: http://maps.googleapis.com/maps/api/js/StaticMapService.GetMapImage?1m2&1i523083&2i348002&2e1&3u12&4m2&1u446&2u505&5m5&1e0&5sen-GB&6sus&10b1&12b1&token=114950
+:body: ''
+:status: 403
+:method: get
+:headers:
+  Content-Type: text/plain; charset=UTF-8
+  X-Content-Type-Options: nosniff
+  Date: Wed, 29 Jun 2016 19:24:30 GMT
+  Pragma: no-cache
+  Expires: Fri, 01 Jan 1990 00:00:00 GMT
+  Cache-Control: no-cache, must-revalidate
+  Server: staticmap
+  X-XSS-Protection: 1; mode=block
+  X-Frame-Options: SAMEORIGIN
+  Accept-Ranges: none
+  Vary: Accept-Encoding
+  Connection: close
+:content: 'The Google Maps API server rejected your request. The Google Maps JavaScript
+  API must be downloaded directly from Google''s servers. Learn more: https://developers.google.com/maps/documentation/javascript/tutorial#Loading_the_Maps_API'

--- a/features/req_cache/get_maps.googleapis.com_aee729a4d44abad9c320e706e92d484062e0f366.yml
+++ b/features/req_cache/get_maps.googleapis.com_aee729a4d44abad9c320e706e92d484062e0f366.yml
@@ -1,0 +1,21 @@
+---
+:scope: 
+:url: http://maps.googleapis.com/maps/api/js/StaticMapService.GetMapImage?1m2&1i523083&2i348022&2e1&3u12&4m2&1u446&2u465&5m5&1e0&5sen-GB&6sus&10b1&12b1&token=11062
+:body: ''
+:status: 403
+:method: get
+:headers:
+  Content-Type: text/plain; charset=UTF-8
+  X-Content-Type-Options: nosniff
+  Date: Wed, 29 Jun 2016 19:24:32 GMT
+  Pragma: no-cache
+  Expires: Fri, 01 Jan 1990 00:00:00 GMT
+  Cache-Control: no-cache, must-revalidate
+  Server: staticmap
+  X-XSS-Protection: 1; mode=block
+  X-Frame-Options: SAMEORIGIN
+  Accept-Ranges: none
+  Vary: Accept-Encoding
+  Connection: close
+:content: 'The Google Maps API server rejected your request. The Google Maps JavaScript
+  API must be downloaded directly from Google''s servers. Learn more: https://developers.google.com/maps/documentation/javascript/tutorial#Loading_the_Maps_API'

--- a/features/req_cache/get_maps.googleapis.com_f94de58a8f3d06b7d8e8fd11dd17ce15153215f7.yml
+++ b/features/req_cache/get_maps.googleapis.com_f94de58a8f3d06b7d8e8fd11dd17ce15153215f7.yml
@@ -1,0 +1,21 @@
+---
+:scope: 
+:url: http://maps.googleapis.com/maps/api/js/StaticMapService.GetMapImage?1m2&1i523083&2i347992&2e1&3u12&4m2&1u446&2u525&5m5&1e0&5sen-GB&6sus&10b1&12b1&token=67136
+:body: ''
+:status: 403
+:method: get
+:headers:
+  Content-Type: text/plain; charset=UTF-8
+  X-Content-Type-Options: nosniff
+  Date: Wed, 29 Jun 2016 19:24:35 GMT
+  Pragma: no-cache
+  Expires: Fri, 01 Jan 1990 00:00:00 GMT
+  Cache-Control: no-cache, must-revalidate
+  Server: staticmap
+  X-XSS-Protection: 1; mode=block
+  X-Frame-Options: SAMEORIGIN
+  Accept-Ranges: none
+  Vary: Accept-Encoding
+  Connection: close
+:content: 'The Google Maps API server rejected your request. The Google Maps JavaScript
+  API must be downloaded directly from Google''s servers. Learn more: https://developers.google.com/maps/documentation/javascript/tutorial#Loading_the_Maps_API'

--- a/features/step_definitions/volunteer_op_steps.rb
+++ b/features/step_definitions/volunteer_op_steps.rb
@@ -8,6 +8,18 @@ And(/^I submit a volunteer op "(.*?)", "(.*?)" on the "(.*?)" page$/) do |title,
   click_on 'Create a Volunteer Opportunity'
 end
 
+Given(/^I submit a volunteer op with address "(.*?)", "(.*?)", "(.*?)", "(.*?)" on the "(.*?)" page$/) do |title, desc, address, postcode, org_name|
+  org = Organisation.find_by_name(org_name)
+  visit organisation_path org
+  click_link 'Create a Volunteer Opportunity'
+  expect(current_path).to eq new_organisation_volunteer_op_path org
+  fill_in 'Title', with: title
+  fill_in 'Description', with: desc
+  fill_in 'Address', with: address
+  fill_in 'Postcode', with: postcode
+  click_on 'Create a Volunteer Opportunity'
+end
+
 Given(/^I run the import doit service( with a radius of (\d+\.?\d*) miles)?$/)do |override, radius|
   if override
     ImportDoItVolunteerOpportunities.with radius.to_f
@@ -59,4 +71,17 @@ Given(/^the map should show the do\-it opportunity titled (.*)$/) do |opportunit
   click_twice icon
   expect(page).to have_css('.arrow_box')
   expect(find('.arrow_box').text).to include(opportunity_title)
+end
+
+When(/^I set new volunteer opportunity location to "(.*?)", "(.*?)"$/) do |addr, pc|
+  fill_in 'Address', with: addr
+  fill_in 'Postcode', with: pc
+  click_button 'Update a Volunteer Opportunity'
+end
+
+Then(/^I should see "(.*?)", "(.*?)", "(.*?)" and "(.*?)"$/) do |title, desc, address, org|
+  expect(page).to have_content title
+  expect(page).to have_content desc
+  expect(page).to have_content address
+  expect(page).to have_content org
 end

--- a/features/step_definitions/volunteer_op_steps.rb
+++ b/features/step_definitions/volunteer_op_steps.rb
@@ -28,6 +28,14 @@ Given(/^I run the import doit service( with a radius of (\d+\.?\d*) miles)?$/)do
   end
 end
 
+Then(/^all imported volunteer ops have latitude and longitude coordinates$/) do
+  all_with_coordiante = VolunteerOp.where(source: 'doit').all? do |op|
+    op.longitude && op.latitude?
+  end
+  expect(all_with_coordiante).to eq(true)
+end
+
+
 Given(/^there is a doit volunteer op named "(.*?)"$/) do |title|
   VolunteerOp.create(title: title,description: 'description content', source: 'doit', organisation_id: 1)
 end

--- a/features/vcr_cassettes/Org_superadmin_creating_a_volunteer_work_opportunity/Org-superadmins_can_create_a_volunteer_opportunity_with_different_address.yml
+++ b/features/vcr_cassettes/Org_superadmin_creating_a_volunteer_work_opportunity/Org-superadmins_can_create_a_volunteer_opportunity_with_different_address.yml
@@ -1,0 +1,116 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=Station%20Rd,%20HA8%207BD&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 29 Jun 2016 19:22:29 GMT
+      Expires:
+      - Thu, 30 Jun 2016 19:22:29 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '549'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - public, max-age=86400
+      Age:
+      - '162'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Station Road",
+                       "short_name" : "Station Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Edgware",
+                       "short_name" : "Edgware",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edgware",
+                       "short_name" : "Edgware",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Greater London",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "HA8 7BD",
+                       "short_name" : "HA8 7BD",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Station Rd, Edgware, Greater London HA8 7BD, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.6134049,
+                          "lng" : -0.2742465000000001
+                       },
+                       "southwest" : {
+                          "lat" : 51.6113076,
+                          "lng" : -0.2768678
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.61293620000001,
+                       "lng" : -0.2768678
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.6137052302915,
+                          "lng" : -0.274208169708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.6110072697085,
+                          "lng" : -0.2769061302915021
+                       }
+                    }
+                 },
+                 "partial_match" : true,
+                 "place_id" : "ChIJa22KIKQWdkgR9R1b18_XLD8",
+                 "types" : [ "route" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 19:25:11 GMT
+recorded_with: VCR 2.9.3

--- a/features/vcr_cassettes/Super_Admin_can_edit_volunteer_opportunites/Super_Admin_successfully_changes_volunteer_opportunity_location.yml
+++ b/features/vcr_cassettes/Super_Admin_can_edit_volunteer_opportunites/Super_Admin_successfully_changes_volunteer_opportunity_location.yml
@@ -1,0 +1,114 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=Station%20Rd,%20HA8%207BD&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 29 Jun 2016 19:22:29 GMT
+      Expires:
+      - Thu, 30 Jun 2016 19:22:29 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '549'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "Station Road",
+                       "short_name" : "Station Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Edgware",
+                       "short_name" : "Edgware",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edgware",
+                       "short_name" : "Edgware",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Greater London",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "HA8 7BD",
+                       "short_name" : "HA8 7BD",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "Station Rd, Edgware, Greater London HA8 7BD, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.6134049,
+                          "lng" : -0.2742465000000001
+                       },
+                       "southwest" : {
+                          "lat" : 51.6113076,
+                          "lng" : -0.2768678
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.61293620000001,
+                       "lng" : -0.2768678
+                    },
+                    "location_type" : "GEOMETRIC_CENTER",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.6137052302915,
+                          "lng" : -0.274208169708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.6110072697085,
+                          "lng" : -0.2769061302915021
+                       }
+                    }
+                 },
+                 "partial_match" : true,
+                 "place_id" : "ChIJa22KIKQWdkgR9R1b18_XLD8",
+                 "types" : [ "route" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 19:22:29 GMT
+recorded_with: VCR 2.9.3

--- a/features/volunteer_opportunities/create_volunteer_opportunities.feature
+++ b/features/volunteer_opportunities/create_volunteer_opportunities.feature
@@ -26,6 +26,12 @@ Feature: Org superadmin creating a volunteer work opportunity
     Then I should be on the show page for the volunteer_op titled "Hard Work"
     And I should see "Hard Work", "For no pay" and "Organisation: Friendly"
 
+  @vcr @javascript  
+  Scenario: Org-superadmins can create a volunteer opportunity with different address
+    Given I am signed in as a charity worker related to "Friendly"
+    And I submit a volunteer op with address "Ops1", "For free", "Station Rd", "HA8 7BD" on the "Friendly" page
+    And I should see "Ops1", "For free", "Station Rd, HA8 7BD" and "Organisation: Friendly"
+    
   Scenario: Org-superadmins can create a volunteer opportunity but get warning with invalid data
     Given I am signed in as a charity worker related to "Friendly"
     And I submit a volunteer op "", "" on the "Friendly" page

--- a/features/volunteer_opportunities/show_volunteer_opportunity.feature
+++ b/features/volunteer_opportunities/show_volunteer_opportunity.feature
@@ -16,8 +16,10 @@ Feature: As a member of the public
   Scenario: See a volunteer opportunity and hyperlink
     Given I visit the show page for the volunteer_op titled "Office Support"
     Then I should see:
-      | title          | description                     | organisation              |
-      | Office Support | Help with printing and copying. | Indian Elders Association |
+      | title              | description                                     | organisation              | different_address  | address    | postcode   |
+      | Litter Box Scooper | Assist with feline sanitation   test@test.com   | Cats Are Us               | 0                  |            |            |
+      | Office Support     | Help with printing and copying. http://test.com | Indian Elders Association | 0                  |            |            |
+      | Mini Bus Driver    | Drive elders on tours. http://test.com          | Indian Elders Association | 1                  | Station Rd |  HA8 7BD   | 
     And I click "Indian Elders Association"
     Then I should be on the show page for the organisation named "Indian Elders Association"
 
@@ -28,3 +30,8 @@ Feature: As a member of the public
   Scenario: See emails in volunteer opportunity pages are hyperlinked
     Given I visit the show page for the volunteer_op titled "Litter Box Scooper"
     Then the page includes email hyperlink "test@test.com"
+    
+  Scenario: See volunteer opportunity location with different address
+    Given I visit the show page for the volunteer_op titled "Mini Bus Driver"
+    Then I should see "Volunteer opportunity location: Station Rd, HA8 7BD" 
+    

--- a/spec/models/volunteer_op_spec.rb
+++ b/spec/models/volunteer_op_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe VolunteerOp, :type => :model do
+describe VolunteerOp, type: :model do
   it 'must have a title' do
     v = VolunteerOp.new(title: '')
     v.valid?
@@ -115,6 +115,55 @@ describe VolunteerOp, :type => :model do
 
     it 'find records where title or description match search text' do
       expect(VolunteerOp.search_for_text('good')).to eq([vol_op2])
+    end
+  end
+  
+  describe '#full_address' do
+    let(:details) do
+      {
+        title: 'test',
+        description: 'description',
+        address: 'Station Rd',
+        postcode: 'HA8 7BD',
+        organisation_id: 1
+      } 
+    end
+    let!(:vol_op) { FactoryGirl.create :volunteer_op, details }
+    
+    it 'returns a full address' do
+      expect(vol_op.full_address).to eq 'Station Rd, HA8 7BD'
+    end
+  end
+  
+  describe 'set\'s volunteer_op lat and lng' do
+    let(:details) do
+      {
+        title: 'test',
+        description: 'description', 
+        address: 'Station Rd',
+        postcode: 'HA8 7BD',
+        organisation_id: 1
+      } 
+    end
+    let!(:vol_op) { FactoryGirl.create :volunteer_op, details }   
+    
+    it 'has a different address' do
+      expect(vol_op.address_complete?).to be_truthy
+    end
+    
+    it 'has not have different address' do
+      vol_op.address = ''
+      vol_op.postcode = '' 
+      vol_op.save!
+      expect(vol_op.address_complete?).to be_falsey
+    end
+    
+    it 'should clean the lat and lng if no address' do
+      vol_op.address = ''
+      vol_op.postcode = ''
+      vol_op.save!
+      expect(vol_op.latitude).to be_nil
+      expect(vol_op.longitude).to be_nil
     end
   end
 end

--- a/spec/models/volunteer_op_spec.rb
+++ b/spec/models/volunteer_op_spec.rb
@@ -134,38 +134,41 @@ describe VolunteerOp, type: :model do
       expect(vol_op.full_address).to eq 'Station Rd, HA8 7BD'
     end
   end
+
+  describe '#address_compelete?' do
+    context 'volunteer op has address and postcode' do
+      it 'returns true' do
+        vol_op = build(:volunteer_op, address: 'not nil', postcode: 'HA1 4HZ')
+        expect(vol_op.address_complete?).to be_truthy
+      end
+    end
+    context 'volunteer op does not have address or postcode' do
+      it 'returns false' do
+        vol_op = build(:volunteer_op, address: nil, postcode: nil)
+        expect(vol_op.address_complete?).to be_falsey
+      end
+    end
+  end
+
+
   
-  describe 'set\'s volunteer_op lat and lng' do
-    let(:details) do
-      {
-        title: 'test',
-        description: 'description', 
-        address: 'Station Rd',
-        postcode: 'HA8 7BD',
-        organisation_id: 1
-      } 
+  describe 'clear_lat_lng callback' do
+    let(:vol_op) { build(:volunteer_op, source: source, address: nil, postcode: nil, longitude: -0.393924, latitude: 51.5843) }
+    context 'local volunteer op type' do
+      let(:source)  { 'local' }
+      it 'should clean the lat and lng if no address' do
+        vol_op.save
+        expect(vol_op.latitude).to be_nil
+        expect(vol_op.longitude).to be_nil
+      end
     end
-    let!(:vol_op) { FactoryGirl.create :volunteer_op, details }   
-    
-    it 'has a different address' do
-      expect(vol_op.address_complete?).to be_truthy
-    end
-    
-    it 'has not have different address' do
-      vol_op.address = ''
-      vol_op.postcode = '' 
-      vol_op.save!
-      expect(vol_op.address_complete?).to be_falsey
-    end
-    
-    it 'should not clean the lat and lng if no address' do
-      vol_op.address = ''
-      vol_op.postcode = ''
-      vol_op.longitude = -0.393924
-      vol_op.latitude = 51.5843
-      vol_op.save!
-      expect(vol_op.latitude).not_to be_nil
-      expect(vol_op.longitude).not_to be_nil
+    context 'non local volunteer op type' do
+      let(:source)  { 'doit' }
+      it 'should not clean the lat and lng if no address' do
+        vol_op.save
+        expect(vol_op.latitude).not_to be_nil
+        expect(vol_op.longitude).not_to be_nil
+      end
     end
   end
 end

--- a/spec/models/volunteer_op_spec.rb
+++ b/spec/models/volunteer_op_spec.rb
@@ -158,12 +158,14 @@ describe VolunteerOp, type: :model do
       expect(vol_op.address_complete?).to be_falsey
     end
     
-    it 'should clean the lat and lng if no address' do
+    it 'should not clean the lat and lng if no address' do
       vol_op.address = ''
       vol_op.postcode = ''
+      vol_op.longitude = -0.393924
+      vol_op.latitude = 51.5843
       vol_op.save!
-      expect(vol_op.latitude).to be_nil
-      expect(vol_op.longitude).to be_nil
+      expect(vol_op.latitude).not_to be_nil
+      expect(vol_op.longitude).not_to be_nil
     end
   end
 end

--- a/spec/services/import_doit_opportunities_spec.rb
+++ b/spec/services/import_doit_opportunities_spec.rb
@@ -73,4 +73,15 @@ describe ImportDoItVolunteerOpportunities do
     end
   end
 
+  context 'vol ops with missing long & lat' do
+    let(:response) { double :response, body: File.read('test/fixtures/doit_no_coordinates.json') }
+
+    it 'does not persist the vol op parsed' do
+      allow(http_party).to receive(:get).and_return(response)
+      expect(model_klass).not_to receive(:find_or_create_by)
+      list_volunteer_opportunities
+    end
+
+  end
+
 end

--- a/spec/views/volunteer_ops/new.html.erb_spec.rb
+++ b/spec/views/volunteer_ops/new.html.erb_spec.rb
@@ -1,16 +1,24 @@
 require 'rails_helper'
 
-describe "volunteer_ops/new", :type => :view do
-  let (:organisation) { double :organisation, id: 3 }
+describe 'volunteer_ops/new', type: :view do
+  let (:organisation) { double :organisation, id: 3, address: 'home', postcode: 'wherever'}
   let (:user) { double :user, organisation: organisation } 
   before(:each) do
+    create(:organisation, 
+      name: 'Happy org',
+      address: '87 Roxeth Green Avenue, Harrow',
+      postcode: 'HA2 8AB'
+    )
     assign(:volunteer_op, stub_model(VolunteerOp,
-      :title => "MyString",
-      :description => "MyText",
-      :organisation => nil
+      title: 'MyString',
+      description: 'MyText',
+      organisation: nil
     ).as_new_record)
-    params[:organisation_id] = 4
+    params[:organisation_id] = 'Happy org'
+
+    @organisation = assign(:organisation, organisation)
   end
+
 
   it 'uses a partial that needs local variables' do
     url = organisation_volunteer_ops_path(params[:organisation_id])
@@ -18,13 +26,18 @@ describe "volunteer_ops/new", :type => :view do
     expect(view).to render_template(partial: '_form', locals: { submission_url: url })
   end
 
-  it "renders new volunteer_op form" do
+  it 'renders new volunteer_op form' do
     render
-    expect(rendered).to have_xpath("//form[@action='#{organisation_volunteer_ops_path(organisation_id:4)}'][@method='post']")
-    expect(rendered).to have_xpath("//form[@action='#{organisation_volunteer_ops_path(organisation_id:4)}'][@method='post']
+    # byebug
+    expect(rendered).to have_xpath("//form[@action='#{organisation_volunteer_ops_path(organisation_id: 'Happy org')}'][@method='post']")
+    expect(rendered).to have_xpath("//form[@action='#{organisation_volunteer_ops_path(organisation_id: 'Happy org')}'][@method='post']
       //input[@id='volunteer_op_title'][@name='volunteer_op[title]']")
-    expect(rendered).to have_xpath("//form[@action='#{organisation_volunteer_ops_path(organisation_id:4)}'][@method='post']
+    expect(rendered).to have_xpath("//form[@action='#{organisation_volunteer_ops_path(organisation_id: 'Happy org')}'][@method='post']
       //textarea[@id='volunteer_op_description'][@name='volunteer_op[description]']")
+    expect(rendered).to have_xpath("//form[@action='#{organisation_volunteer_ops_path(organisation_id: 'Happy org')}'][@method='post']
+      //input[@id='volunteer_op_address'][@name='volunteer_op[address]']")
+    expect(rendered).to have_xpath("//form[@action='#{organisation_volunteer_ops_path(organisation_id: 'Happy org')}'][@method='post']
+      //input[@id='volunteer_op_postcode'][@name='volunteer_op[postcode]']")
   end
 
   it "should have a Create Volunteer Opportunity button" do
@@ -32,9 +45,9 @@ describe "volunteer_ops/new", :type => :view do
     expect(rendered).to have_css 'input[value="Create a Volunteer Opportunity"]'
   end
 
-  it "only has 1 text area and 1 text input" do
+  it 'only has 1 text area and 1 text input' do
     render
-    expect(rendered).to have_css("textarea", :count => 1 )
-    expect(rendered).to have_css("input[type=text]", :count => 1 )
+    expect(rendered).to have_css('textarea', count: 1 )
+    expect(rendered).to have_css('input[type=text]', count: 3 )
   end
 end

--- a/spec/views/volunteer_ops/show.html.erb_spec.rb
+++ b/spec/views/volunteer_ops/show.html.erb_spec.rb
@@ -1,15 +1,18 @@
 require 'rails_helper'
 
-describe "volunteer_ops/show", :type => :view do
+describe 'volunteer_ops/show', type: :view do
   let(:org) { double :organisation,
-    :name => 'Friendly',
-    :id => 1
+    name: 'Friendly',
+    id: 1
   }
   let(:op) { double :volunteer_op,
-    :title => "Honorary treasurer",
-    :description => "Great opportunity to build your portfolio!",
-    :organisation => org,
-    :id => 3
+    title: 'Honorary treasurer',
+    description: 'Great opportunity to build your portfolio!',
+    organisation: org,
+    address: 'Station Rd',
+    postcode: 'HA8 7BD',
+    id: 3,
+    address_complete?: true
   }
   before(:each) do
     @volunteer_op = assign(:volunteer_op, op)
@@ -19,12 +22,16 @@ describe "volunteer_ops/show", :type => :view do
     render
     expect(rendered).to have_content op.title
     expect(rendered).to have_content op.description
+    expect(rendered).to have_content op.address
+    expect(rendered).to have_content op.postcode
     expect(rendered).to have_content op.organisation.name
   end
 
   it "gets various model attributes" do
     expect(@volunteer_op).to receive :title
     expect(@volunteer_op).to receive :description
+    expect(@volunteer_op).to receive :address
+    expect(@volunteer_op).to receive :postcode
     expect(@volunteer_op).to receive(:organisation) {org}
     expect(org).to receive(:name)
     render

--- a/test/fixtures/doit_no_coordinates.json
+++ b/test/fixtures/doit_no_coordinates.json
@@ -1,0 +1,597 @@
+{
+  "data":{
+    "items":[
+      {
+        "address_1":"43 Claremont Road,",
+        "city":"Wealdstone",
+        "created":"2014-10-27T09:50:38.557408+00:00",
+        "description":"Assistant Leaders are responsible, with Leaders, helpers and members, for planning and running the weekly activities for 8-10 year olds!\n\nIt is a fun and rewarding role, allowing you to watch the young people enjoy the activities you organize, as well as being involved in their development as they grow in confidence and ability. \n\nThe Scout Association provides a wide range of books and electronic resources to aid volunteers plan their activities together with an award winning training scheme and on-line programme resources",
+        "for_recruiter":{
+          "contact_name":null,
+          "created":"2014-10-27T09:50:29.663966+00:00",
+          "email":"debbie.evans@scouts.org.uk",
+          "id":"33c3a2ab-06e2-4fab-a865-a8518cd842ca",
+          "logo":[
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.125x125.jpg",
+              "height":125,
+              "width":125
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.109x109.jpg",
+              "height":109,
+              "width":109
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.76x76.jpg",
+              "height":76,
+              "width":76
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.50x50.jpg",
+              "height":50,
+              "width":50
+            }
+          ],
+          "name":"Scouts - Scout Association - Greater London Region",
+          "phone":"01635 247845",
+          "rating":"3.00",
+          "slug":"greater-london-region"
+        },
+        "for_recruiter_id":"33c3a2ab-06e2-4fab-a865-a8518cd842ca",
+        "id":"d1f8f924-db77-48c9-82a9-7433bbc9a048",
+        "interests":[
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.246077+00:00",
+            "id":"c1a66cf8-a685-4300-8f69-6d47a0bd93e0",
+            "name":"Recreation",
+            "parent_id":"cd7d0590-2800-45b4-8084-b475562e73f4",
+            "slug":"recreation",
+            "updated":"2014-10-26T17:24:26.246096+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.278190+00:00",
+            "id":"8f0a66e0-30e7-4bdd-a190-7a9a36afcedd",
+            "name":"Children",
+            "parent_id":"56fabd4e-bac3-484f-9f55-448445f83481",
+            "slug":"children",
+            "updated":"2014-10-26T17:24:26.278210+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.271205+00:00",
+            "id":"8678f792-d24e-4810-99d5-c6e6ba4196a4",
+            "name":"Families",
+            "parent_id":"56fabd4e-bac3-484f-9f55-448445f83481",
+            "slug":"families",
+            "updated":"2014-10-26T17:24:26.271224+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.274701+00:00",
+            "id":"02b052fd-4f3d-418b-9542-0b980533b03b",
+            "name":"Young people",
+            "parent_id":"56fabd4e-bac3-484f-9f55-448445f83481",
+            "slug":"young-people",
+            "updated":"2014-10-26T17:24:26.274721+00:00"
+          }
+        ],
+        "is_new":false,
+        "lat":null,
+        "lng":null,
+        "location":null,
+        "location_id":null,
+        "location_name":null,
+        "location_type":"SL",
+        "micro_availability":[
+
+        ],
+        "owner_recruiter":{
+          "contact_name":null,
+          "created":"2014-10-27T09:50:29.663966+00:00",
+          "email":"debbie.evans@scouts.org.uk",
+          "id":"33c3a2ab-06e2-4fab-a865-a8518cd842ca",
+          "logo":[
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.125x125.jpg",
+              "height":125,
+              "width":125
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.109x109.jpg",
+              "height":109,
+              "width":109
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.76x76.jpg",
+              "height":76,
+              "width":76
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.50x50.jpg",
+              "height":50,
+              "width":50
+            }
+          ],
+          "name":"Scouts - Scout Association - Greater London Region",
+          "phone":"01635 247845",
+          "rating":"3.00",
+          "slug":"greater-london-region"
+        },
+        "owner_recruiter_id":"33c3a2ab-06e2-4fab-a865-a8518cd842ca",
+        "photo":[
+          {
+            "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/opps/photos/IMG_0085_k7cxdpYbjaec74qAFkkh6n.616x318.jpg",
+            "height":318,
+            "width":616
+          },
+          {
+            "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/opps/photos/IMG_0085_k7cxdpYbjaec74qAFkkh6n.308x159.jpg",
+            "height":159,
+            "width":308
+          },
+          {
+            "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/opps/photos/IMG_0085_k7cxdpYbjaec74qAFkkh6n.243x124.jpg",
+            "height":124,
+            "width":243
+          },
+          {
+            "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/opps/photos/IMG_0085_k7cxdpYbjaec74qAFkkh6n.170x87.jpg",
+            "height":87,
+            "width":170
+          }
+        ],
+        "postcode":"HA3 7AU",
+        "rating":"0.00",
+        "specific_end_date":null,
+        "specific_start_date":"2016-01-25T09:25:58.431000+00:00",
+        "status":"live",
+        "title":"Cub Scout Leader (volunteering with 8-10 year olds) 27th Harrow",
+        "updated":"2016-01-25T09:30:07.758522+00:00",
+        "working_from_home":false
+      },
+      {
+        "address_1":"43 Claremont Road,",
+        "city":"Wealdstone",
+        "created":"2014-10-27T09:51:53.864127+00:00",
+        "description":"By Volunteering to work with scouts, you will be responsible, along with the other leaders, helpers and members for planning and running the weekly activities for 10 - 14 year olds! \n\nIt is a fun and rewarding role, allowing you to watch the young people enjoy the activities you organise, as well being involved in their development as they grow in confidence and ability. \n\nThe Scout Association provides a wide range of books and electronic resources to aid volunteers plan their activities together with an award winning training scheme and on-line programme resources",
+        "for_recruiter":{
+          "contact_name":null,
+          "created":"2014-10-27T09:50:29.663966+00:00",
+          "email":"debbie.evans@scouts.org.uk",
+          "id":"33c3a2ab-06e2-4fab-a865-a8518cd842ca",
+          "logo":[
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.125x125.jpg",
+              "height":125,
+              "width":125
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.109x109.jpg",
+              "height":109,
+              "width":109
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.76x76.jpg",
+              "height":76,
+              "width":76
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.50x50.jpg",
+              "height":50,
+              "width":50
+            }
+          ],
+          "name":"Scouts - Scout Association - Greater London Region",
+          "phone":"01635 247845",
+          "rating":"3.00",
+          "slug":"greater-london-region"
+        },
+        "for_recruiter_id":"33c3a2ab-06e2-4fab-a865-a8518cd842ca",
+        "id":"79ae1022-9059-40c0-82dd-3f5b15dd796a",
+        "interests":[
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.246077+00:00",
+            "id":"c1a66cf8-a685-4300-8f69-6d47a0bd93e0",
+            "name":"Recreation",
+            "parent_id":"cd7d0590-2800-45b4-8084-b475562e73f4",
+            "slug":"recreation",
+            "updated":"2014-10-26T17:24:26.246096+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.278190+00:00",
+            "id":"8f0a66e0-30e7-4bdd-a190-7a9a36afcedd",
+            "name":"Children",
+            "parent_id":"56fabd4e-bac3-484f-9f55-448445f83481",
+            "slug":"children",
+            "updated":"2014-10-26T17:24:26.278210+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.271205+00:00",
+            "id":"8678f792-d24e-4810-99d5-c6e6ba4196a4",
+            "name":"Families",
+            "parent_id":"56fabd4e-bac3-484f-9f55-448445f83481",
+            "slug":"families",
+            "updated":"2014-10-26T17:24:26.271224+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.274701+00:00",
+            "id":"02b052fd-4f3d-418b-9542-0b980533b03b",
+            "name":"Young people",
+            "parent_id":"56fabd4e-bac3-484f-9f55-448445f83481",
+            "slug":"young-people",
+            "updated":"2014-10-26T17:24:26.274721+00:00"
+          }
+        ],
+        "is_new":false,
+        "lat":null,
+        "lng":null,
+        "location":null,
+        "location_id":null,
+        "location_name":null,
+        "location_type":"SL",
+        "micro_availability":[
+
+        ],
+        "owner_recruiter":{
+          "contact_name":null,
+          "created":"2014-10-27T09:50:29.663966+00:00",
+          "email":"debbie.evans@scouts.org.uk",
+          "id":"33c3a2ab-06e2-4fab-a865-a8518cd842ca",
+          "logo":[
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.125x125.jpg",
+              "height":125,
+              "width":125
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.109x109.jpg",
+              "height":109,
+              "width":109
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.76x76.jpg",
+              "height":76,
+              "width":76
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/Image_fot_VInspired_adults_z75XoyfZoRmQm396Gxd8g3.50x50.jpg",
+              "height":50,
+              "width":50
+            }
+          ],
+          "name":"Scouts - Scout Association - Greater London Region",
+          "phone":"01635 247845",
+          "rating":"3.00",
+          "slug":"greater-london-region"
+        },
+        "owner_recruiter_id":"33c3a2ab-06e2-4fab-a865-a8518cd842ca",
+        "photo":[
+          {
+            "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/opps/photos/X0A0667_6ptyC4xw2nhqJzudZRwLhS.616x318.jpg",
+            "height":318,
+            "width":616
+          },
+          {
+            "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/opps/photos/X0A0667_6ptyC4xw2nhqJzudZRwLhS.308x159.jpg",
+            "height":159,
+            "width":308
+          },
+          {
+            "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/opps/photos/X0A0667_6ptyC4xw2nhqJzudZRwLhS.243x124.jpg",
+            "height":124,
+            "width":243
+          },
+          {
+            "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/opps/photos/X0A0667_6ptyC4xw2nhqJzudZRwLhS.170x87.jpg",
+            "height":87,
+            "width":170
+          }
+        ],
+        "postcode":"HA3 7AU",
+        "rating":"0.00",
+        "specific_end_date":null,
+        "specific_start_date":"2016-01-29T16:05:04.445000+00:00",
+        "status":"live",
+        "title":"Scout Leader (volunteering with 10-14 year olds) 27th Harrow",
+        "updated":"2016-01-29T15:50:10.669967+00:00",
+        "working_from_home":false
+      },
+      {
+        "address_1":"3RD FLOOR PREMIER HOUSE",
+        "city":"WEALDSTONE",
+        "created":"2015-03-09T18:30:36.076789+00:00",
+        "description":"You will be trained to deliver chair-based falls prevention exercises to older people who have had falls or who are considered to be at risk of falls. The exercise programme is agreed in advance with the client after the client's needs have been assessed by the Co-ordinator. Clients are matched with volunteers for six sessions, usually weekly, and volunteers should be prepared to commit to volunteering for a minimum of six months, part-time.",
+        "for_recruiter":{
+          "contact_name":"Ramesh perinparaja",
+          "created":"2015-03-04T14:16:54.515493+00:00",
+          "email":"info@capablecommunities.co.uk",
+          "id":"72dc3411-b4bc-4534-946a-b9de53280311",
+          "logo":[
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.125x125.png",
+              "height":125,
+              "width":125
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.109x109.png",
+              "height":109,
+              "width":109
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.76x76.png",
+              "height":76,
+              "width":76
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.50x50.png",
+              "height":50,
+              "width":50
+            }
+          ],
+          "name":"Harrow Volunteer Centre (Capable Communities Ltd)",
+          "phone":"020 3 468 2282",
+          "rating":"2.00",
+          "slug":"third-sector-potential"
+        },
+        "for_recruiter_id":"72dc3411-b4bc-4534-946a-b9de53280311",
+        "id":"c8302287-779e-460b-aeb5-c59268120c60",
+        "interests":[
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.260228+00:00",
+            "id":"3fd515b4-6e1a-41a1-bad9-ea401937555b",
+            "name":"Older people",
+            "parent_id":"56fabd4e-bac3-484f-9f55-448445f83481",
+            "slug":"older-people",
+            "updated":"2014-10-26T17:24:26.260247+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:25.849110+00:00",
+            "id":"2a13e327-cdc3-4a63-a737-52c29ee8f454",
+            "name":"Sport",
+            "parent_id":"cd7d0590-2800-45b4-8084-b475562e73f4",
+            "slug":"sport",
+            "updated":"2014-10-26T17:24:25.849131+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:25.579841+00:00",
+            "id":"c904084b-934a-4915-9937-833020adfe6d",
+            "name":"Health & Safety",
+            "parent_id":"a0be8981-33c6-46df-a3fe-2100a575695f",
+            "slug":"health-safety",
+            "updated":"2014-10-26T17:24:25.579861+00:00"
+          }
+        ],
+        "is_new":false,
+        "lat":null,
+        "lng":null,
+        "location":null,
+        "location_id":null,
+        "location_name":null,
+        "location_type":"SL",
+        "micro_availability":[
+
+        ],
+        "owner_recruiter":{
+          "contact_name":"Ramesh perinparaja",
+          "created":"2015-03-04T14:16:54.515493+00:00",
+          "email":"info@capablecommunities.co.uk",
+          "id":"72dc3411-b4bc-4534-946a-b9de53280311",
+          "logo":[
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.125x125.png",
+              "height":125,
+              "width":125
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.109x109.png",
+              "height":109,
+              "width":109
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.76x76.png",
+              "height":76,
+              "width":76
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.50x50.png",
+              "height":50,
+              "width":50
+            }
+          ],
+          "name":"Harrow Volunteer Centre (Capable Communities Ltd)",
+          "phone":"020 3 468 2282",
+          "rating":"2.00",
+          "slug":"third-sector-potential"
+        },
+        "owner_recruiter_id":"72dc3411-b4bc-4534-946a-b9de53280311",
+        "photo":[
+
+        ],
+        "postcode":"HA3 7TS",
+        "rating":"0.00",
+        "specific_end_date":"2016-03-07T00:00:00+00:00",
+        "specific_start_date":"2015-07-29T15:40:38.303000+00:00",
+        "status":"live",
+        "title":"Falls Support Volunteers for Age UK",
+        "updated":"2015-07-29T15:49:04.153733+00:00",
+        "working_from_home":false
+      },
+      {
+        "address_1":"Age Uk Harrow",
+        "city":"Wealdstone",
+        "created":"2015-03-10T12:21:50.366074+00:00",
+        "description":"Age UK Harrow is offering a free 12 weeks information and advice training programmes, to be followed by further on the job training with an experienced advisor. Selection of candidates is subject to a satisfactory DBS check and references. Candidates who successfully ccomplete our training programme will gain a rewarding volunteering role as well as transferable skills.",
+        "for_recruiter":{
+          "contact_name":"Ramesh perinparaja",
+          "created":"2015-03-04T14:16:54.515493+00:00",
+          "email":"info@capablecommunities.co.uk",
+          "id":"72dc3411-b4bc-4534-946a-b9de53280311",
+          "logo":[
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.125x125.png",
+              "height":125,
+              "width":125
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.109x109.png",
+              "height":109,
+              "width":109
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.76x76.png",
+              "height":76,
+              "width":76
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.50x50.png",
+              "height":50,
+              "width":50
+            }
+          ],
+          "name":"Harrow Volunteer Centre (Capable Communities Ltd)",
+          "phone":"020 3 468 2282",
+          "rating":"2.00",
+          "slug":"third-sector-potential"
+        },
+        "for_recruiter_id":"72dc3411-b4bc-4534-946a-b9de53280311",
+        "id":"00fb68ec-16b1-48eb-a2d6-bf0565ece64b",
+        "interests":[
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.142866+00:00",
+            "id":"6fc9bb15-1728-4d4d-bdab-51be247acba0",
+            "name":"Social care",
+            "parent_id":"24620d05-41c1-4884-a0cb-f70054faba9b",
+            "slug":"social-care",
+            "updated":"2014-10-26T17:24:26.142886+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.235376+00:00",
+            "id":"397cac61-1077-4f78-a8e5-d8c3dd29cde4",
+            "name":"Mental Health",
+            "parent_id":"24620d05-41c1-4884-a0cb-f70054faba9b",
+            "slug":"mental-health",
+            "updated":"2014-10-26T17:24:26.235395+00:00"
+          },
+          {
+            "children":[
+
+            ],
+            "created":"2014-10-26T17:24:26.260228+00:00",
+            "id":"3fd515b4-6e1a-41a1-bad9-ea401937555b",
+            "name":"Older people",
+            "parent_id":"56fabd4e-bac3-484f-9f55-448445f83481",
+            "slug":"older-people",
+            "updated":"2014-10-26T17:24:26.260247+00:00"
+          }
+        ],
+        "is_new":false,
+        "lat":null,
+        "lng":null,
+        "location":null,
+        "location_id":null,
+        "location_name":null,
+        "location_type":"SL",
+        "micro_availability":[
+
+        ],
+        "owner_recruiter":{
+          "contact_name":"Ramesh perinparaja",
+          "created":"2015-03-04T14:16:54.515493+00:00",
+          "email":"info@capablecommunities.co.uk",
+          "id":"72dc3411-b4bc-4534-946a-b9de53280311",
+          "logo":[
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.125x125.png",
+              "height":125,
+              "width":125
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.109x109.png",
+              "height":109,
+              "width":109
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.76x76.png",
+              "height":76,
+              "width":76
+            },
+            {
+              "absolute_url":"https://s3-eu-west-1.amazonaws.com/media.do-it.org/orgs/logos/people-KTne6RLEc.50x50.png",
+              "height":50,
+              "width":50
+            }
+          ],
+          "name":"Harrow Volunteer Centre (Capable Communities Ltd)",
+          "phone":"020 3 468 2282",
+          "rating":"2.00",
+          "slug":"third-sector-potential"
+        },
+        "owner_recruiter_id":"72dc3411-b4bc-4534-946a-b9de53280311",
+        "photo":[
+
+        ],
+        "postcode":"HA3 7TS",
+        "rating":"0.00",
+        "specific_end_date":"2016-05-31T11:05:48+00:00",
+        "specific_start_date":"2015-05-05T13:16:54.471000+00:00",
+        "status":"live",
+        "title":"Office Based Volunteer Advisors for Age UK",
+        "updated":"2015-05-05T13:15:36.315554+00:00",
+        "working_from_home":false
+      }
+    ]
+  },
+  "links":{
+    "self":{
+      "href":"/v1/opportunities",
+      "title":"You are here."
+    }
+  },
+  "meta":{
+    "code":200,
+    "current_page":1,
+    "items_per_page":20,
+    "tenant":"doittrust",
+    "total_items":16,
+    "total_pages":1,
+    "version":"2016.02.11.1"
+  }
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/127384707
Issue description: we had vol op from doit persisted without longitude and latitude. The cause of the issue was an after_validation in Volunteer Op model which set longitude and latitude attributes of record to nil if there is no address.

Work done:
- Remove after_validation in volunteer_op, it sets longitue and latitude
  of record to nil if there is no address

- Add filter for doit vol op to save only vol ops with longitude and
  latitude coordinates
