### PR TITLE
Change ambiguous language in admin notification mails (#338)

### DIFF
--- a/app/views/admin_mailer/edit_org_waiting_for_approval.html.erb
+++ b/app/views/admin_mailer/edit_org_waiting_for_approval.html.erb
@@ -1,4 +1,4 @@
-There is an edit awaiting for superadmin approval to <%= @org.name %>.
+There is an edit awaiting for your approval on <%= @org.name %>.
 
 Please log in to the superadmin interface in order to approve or decline their request.
 

--- a/app/views/admin_mailer/new_user_waiting_for_approval.html.erb
+++ b/app/views/admin_mailer/new_user_waiting_for_approval.html.erb
@@ -1,4 +1,4 @@
-There is a user waiting for superadmin approval to <%= @org_name %>.
+There is a user waiting for your approval on <%= @org_name %>.
 
 Please log in to the superadmin interface in order to approve or decline their request.
 

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -23,12 +23,12 @@ you will be able to update your organisation's directory entry."
 end
 
 And(/^an email should be sent to "(.*?)" as notification of the request for admin status of "(.*?)"$/) do |email, org_name|
-  message = "There is a user waiting for superadmin approval to #{org_name}"
+  message = "There is a user waiting for your approval on #{org_name}"
   expect_email_exists(message: message,email: email)
 end
 
 And(/^an email should be sent to "(.*?)" as notification of the proposed edit to "(.*?)"$/) do |email, org_name|
-  message = "There is an edit awaiting for superadmin approval to #{org_name}."
+  message = "There is an edit awaiting for your approval on #{org_name}."
   expect_email_exists(message: message, email: email)
 end
 

--- a/spec/views/admin_mailer/new_user_waiting_for_approval.html_spec.rb
+++ b/spec/views/admin_mailer/new_user_waiting_for_approval.html_spec.rb
@@ -4,6 +4,8 @@ describe 'admin_mailer/new_user_waiting_for_approval.html.erb', :type => :view d
   it 'should render with org name' do
     assign(:org_name, 'Friendly')
     render
-    expect(render).to have_content("There is a user waiting for superadmin approval to Friendly")
+    expect(render).to have_content(
+      'There is a user waiting for your approval on Friendly'
+    )
   end
 end


### PR DESCRIPTION
Addresses: https://www.pivotaltracker.com/story/show/113746563

* increases devise token duration to 7 days

* increases devise token duration to 7 days

* Change ambiguous language in admin mails [Fixes #113746563]

* Fix spec

* Refactor over Hound comments

* Adjusted feature tests