### PR TITLE
Rerun failing cukes on CI [Finishes #129522757]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
 
 script:
   - bundle exec rake test_with_coveralls
+  - bundle exec rake cucumber:second_try
   - USE_JASMINE_RAKE=true bundle exec rake jasmine:ci
 
 deploy:

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,10 +1,9 @@
 # added require to std_opts: http://stackoverflow.com/a/6829369/2197402
 
 <%
-rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
-rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
 std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --require features/ --tags ~@wip"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
+first_try:  NEVER_FAIL=true  <%= std_opts %> --format rerun --out rerun.txt features
+second_try: NEVER_FAIL=false <%= std_opts %> @rerun.txt

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -158,3 +158,9 @@ end
 After('@time_travel') do
   Timecop.return
 end
+
+# To be used in conjunction with rerun option, so that we don't return a failing
+# exit code until the second try fails
+at_exit do
+  exit 0 if ENV['NEVER_FAIL'] == 'true'
+end

--- a/lib/tasks/coveralls.rake
+++ b/lib/tasks/coveralls.rake
@@ -2,5 +2,5 @@ if ENV['RACK_ENV'] != 'production'
   require 'coveralls/rake/task'
   Coveralls::RakeTask.new
   desc 'Run Rspec and Cucumber tests with coveralls'
-  task :test_with_coveralls => [:spec, 'cucumber:ci', 'coveralls:push']
+  task :test_with_coveralls => [:spec, 'cucumber:first_try', 'coveralls:push']
 end

--- a/lib/tasks/coveralls.rake
+++ b/lib/tasks/coveralls.rake
@@ -2,5 +2,5 @@ if ENV['RACK_ENV'] != 'production'
   require 'coveralls/rake/task'
   Coveralls::RakeTask.new
   desc 'Run Rspec and Cucumber tests with coveralls'
-  task :test_with_coveralls => [:spec, :cucumber, 'coveralls:push']
+  task :test_with_coveralls => [:spec, 'cucumber:ci', 'coveralls:push']
 end

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -29,20 +29,19 @@ begin
     desc 'Run all features'
     task :all => [:ok, :wip]
 
+    desc 'Run all features, record any failures'
     Cucumber::Rake::Task.new(:first_try) do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'first_try'
     end
 
+    desc 'Run failures if any exist'
     Cucumber::Rake::Task.new(:second_try) do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'second_try'
     end
-
-    desc 'Run all features, rerun any failures'
-    task ci: [:first_try, :second_try]
 
     task :statsetup do
       require 'rails/code_statistics'

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -26,14 +26,23 @@ begin
       t.profile = 'wip'
     end
 
-    Cucumber::Rake::Task.new({:rerun => 'db:test:prepare'}, 'Record failing features and run only them if any exist') do |t|
-      t.binary = vendored_cucumber_bin
-      t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'rerun'
-    end
-
     desc 'Run all features'
     task :all => [:ok, :wip]
+
+    Cucumber::Rake::Task.new(:first_try) do |t|
+      t.binary = vendored_cucumber_bin
+      t.fork = true # You may get faster startup if you set this to false
+      t.profile = 'first_try'
+    end
+
+    Cucumber::Rake::Task.new(:second_try) do |t|
+      t.binary = vendored_cucumber_bin
+      t.fork = true # You may get faster startup if you set this to false
+      t.profile = 'second_try'
+    end
+
+    desc 'Run all features, rerun any failures'
+    task ci: [:first_try, :second_try]
 
     task :statsetup do
       require 'rails/code_statistics'


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/742821/stories/129522757

I am running cucumber twice. On the first try, I am [abusing `at_exit`](http://blog.arkency.com/2013/06/are-we-abusing-at-exit/) here to force cucumber to not return a failing (non-zero) exit code if any cukes fail. While running in this `NEVER_FAIL` mode, cucumber writes any failures to `rerun.txt`. On the second try, I am running cucumber again, but only for any contents of `rerun.txt`, and without exit code suppression.

It looks like we've [played with `at_exit` before](https://github.com/cucumber/cucumber-ruby/issues/1004).

I am hoping this rerun behavior reduces the number of false positive failing builds we get on CI.

