### PR TITLE
Refactor cucumber for alerting org proposers [Finishes #105829888]

### DIFF
--- a/db/proposed_organisations/create.rb
+++ b/db/proposed_organisations/create.rb
@@ -1,0 +1,39 @@
+module Db
+  module ProposedOrganisations
+    class Create
+      def initialize(attributes)
+        @attributes = attributes
+      end
+
+      def perform
+        ProposedOrganisation.create!(
+          default_attributes.merge(
+            attributes.except('proposer_email')
+          ).merge('users' => users)
+        )
+      end
+
+      private
+
+      attr_reader :attributes
+
+      def default_attributes
+        {
+          'name'          => 'Unfriendly',
+          'description'   => 'Mourning loved ones',
+          'address'       => '30 pinner road',
+          'postcode'      => 'HA5 4HZ',
+          'telephone'     => '520800000',
+          'website'       => 'http://unfriendly.org',
+          'email'         => 'unfriendly@example.com',
+          'donation_info' => 'www.pleasedonate.com',
+          'non_profit'    => true,
+        }
+      end
+
+      def users
+        User.where(email: attributes['proposer_email'])
+      end
+    end
+  end
+end

--- a/features/admin/admin_moderate_proposed_organisations.feature
+++ b/features/admin/admin_moderate_proposed_organisations.feature
@@ -38,7 +38,7 @@ Feature: Admin moderates an organisation to be added to HarrowCN
   Scenario Outline: superadmin accepting proposed organisations
     Given I accept a proposed organisation called "Unfriendly" with email "<email>"
     Then "<email>" is <action> as an organisation admin of "Unfriendly"
-    And I should see "<message>"
+    And I should see an error flash: "<message>"
     Examples:
       | email                         | action   | message                                                                                       |
       | registered_user-1@example.com | notified | A notification of acceptance was sent to registered_user-1@example.com                        |

--- a/features/admin/admin_moderate_proposed_organisations.feature
+++ b/features/admin/admin_moderate_proposed_organisations.feature
@@ -29,40 +29,23 @@ Feature: Admin moderates an organisation to be added to HarrowCN
     And I should see "You have approved the following organisation"
 
   @vcr
-  Scenario: Registered user is notified when superadmin accepts proposed organisation
-    Given the following proposed organisations exist:
-      | name       | description             | address        | postcode | telephone | website               | email                         | donation_info        | non_profit |
-      | Unfriendly | Mourning loved ones     | 30 pinner road | HA5 4HZ  | 520800000 | http://unfriendly.org | registered_user-1@example.com | www.pleasedonate.com | true       |
-    And I accept the proposed_organisation named "Unfriendly"
-    And an email should be sent to "registered_user-1@example.com" as notification of the acceptance of proposed organisation "Unfriendly"
-    And "registered_user-1@example.com" is an organisation admin of "Unfriendly"
-    And I should see "A notification of acceptance was sent to registered_user-1@example.com"
-
-  @vcr
   Scenario: Unregistered user is invited when superadmin accepts proposed organisation
-    Given the following proposed organisations exist:
-      | name       | description             | address        | postcode | telephone | website               | email                      | donation_info        | non_profit |
-      | Unfriendly | Mourning loved ones     | 30 pinner road | HA5 4HZ  | 520800000 | http://unfriendly.org | unregistered@unfriendly.xx | www.pleasedonate.com | true       |
-    And having accepted the proposed organisation named "Unfriendly", I see "An invitation email was sent to unregistered@unfriendly.xx"
-    And an invitational email should be sent to "unregistered@unfriendly.xx" as notification of the acceptance of proposed organisation "Unfriendly"
-    And "unregistered@unfriendly.xx" is an organisation admin of "Unfriendly"
+    Given I accept a proposed organisation called "Unfriendly" with email "unregistered@unfriendly.xx"
     And I click on the invitation link in the proposed org accepted email to "unregistered@unfriendly.xx"
     And I set my password
     Then I should be on the show page for the organisation named "Unfriendly"
 
   @vcr
-  Scenario: Invalid email garners message when superadmin accepts proposed organisation
-    Given the following proposed organisations exist:
-      | name       | description             | address        | postcode | telephone | website               | email    | donation_info        | non_profit |
-      | Unfriendly | Mourning loved ones     | 30 pinner road | HA5 4HZ  | 520800000 | http://unfriendly.org |  xyt     | www.pleasedonate.com | true       |
-    And having accepted the proposed organisation named "Unfriendly", I see "No invitation email was sent because the email associated with Unfriendly, xyt, seems invalid"
-
-  @vcr
-  Scenario: Blank email garners message when superadmin accepts proposed organisation
-    Given the following proposed organisations exist:
-      | name       | description             | address        | postcode | telephone | website               | email    | donation_info        | non_profit |
-      | Unfriendly | Mourning loved ones     | 30 pinner road | HA5 4HZ  | 520800000 | http://unfriendly.org |          | www.pleasedonate.com | true       |
-    And having accepted the proposed organisation named "Unfriendly", I see "No invitation email was sent because no email is associated with the organisation"
+  Scenario Outline: superadmin accepting proposed organisations
+    Given I accept a proposed organisation called "Unfriendly" with email "<email>"
+    Then "<email>" is <action> as an organisation admin of "Unfriendly"
+    And I should see "<message>"
+    Examples:
+      | email                         | action   | message                                                                                       |
+      | registered_user-1@example.com | notified | A notification of acceptance was sent to registered_user-1@example.com                        |
+      | unregistered@friendly.xx      | invited  | An invitation email was sent to unregistered@friendly.xx                                      |
+      | xyt                           | ignored  | No invitation email was sent because the email associated with Unfriendly, xyt, seems invalid |
+      |                               | ignored  | No invitation email was sent because no email is associated with the organisation             |
 
   @vcr
   Scenario: Superadmin rejects new organisation

--- a/features/admin/admin_moderate_proposed_organisations.feature
+++ b/features/admin/admin_moderate_proposed_organisations.feature
@@ -5,7 +5,6 @@ Feature: Admin moderates an organisation to be added to HarrowCN
   Tracker story ID: https://www.pivotaltracker.com/story/show/742821
 
   Background:
-
     Given the following users are registered:
       | email                         | password | superadmin   | confirmed_at         |
       | superadmin@example.com        | pppppppp | true         | 2007-01-01  10:00:00 |
@@ -23,7 +22,7 @@ Feature: Admin moderates an organisation to be added to HarrowCN
 
   @vcr
   Scenario: Superadmin accepts new organisation
-    And I visit the proposed organisation show page for the proposed organisation that was proposed
+    Given I visit the proposed organisation show page for the proposed organisation that was proposed
     And I press "Accept"
     Then I should be on the show page for the organisation that was proposed
     And I should see "You have approved the following organisation"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -338,6 +338,10 @@ Then /^I should( not)? see "([^"]*)"$/ do |negate, text|
   expect(page).send(expectation_method, have_content(text))
 end
 
+Then /^I should see (a|an) (error|warning|notice|success) flash: "([^"]*)"$/ do |_, flash_type, text|
+  expect(find("#flash_#{flash_type}")).to have_content(text)
+end
+
 Then(/^I should see "(.*?)" within "(.*?)"$/) do |text, selector|
   within('#' + selector) { expect(page).to have_content text}
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -472,10 +472,9 @@ When /^I approve "(.*?)"$/ do |email|
 end
 
 Then(/^"(.*?)" is (not )?an organisation admin of "(.*?)"$/) do |user_email, negative, org_name|
-  user = User.find_by_email(user_email)
-  org = Organisation.find_by_name(org_name)
+  org = Organisation.find_by!(name: org_name)
   expectation = negative ? :not_to : :to
-  expect(user.organisation).send(expectation, eq(org))
+  expect(org.users.pluck(:email)).send(expectation, include(user_email))
 end
 
 When /^I (delete|decline) "(.*?)"$/ do |action, email|

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -32,16 +32,6 @@ And(/^an email should be sent to "(.*?)" as notification of the proposed edit to
   expect_email_exists(message: message, email: email)
 end
 
-Then(/^an email should be sent to "(.*?)" as notification of the acceptance of proposed organisation "(.*?)"$/) do |email, org_name|
-  message = "Thank you for registering your organisation.\n\nWe have granted your request to have it included in our directory.\n\nDetails of your organisation are now live in our directory."
-  expect_email_exists(message: message, email: email, link: organisation_url(Organisation.find_by(name: org_name)) , link_text: "You can edit your organisation details by logging in and editing it directly.")
-end
-
-Then(/^an invitational email should be sent to "(.*?)" as notification of the acceptance of proposed organisation "(.*?)"$/) do |email, org_name|
-  message = "Thank you for registering your organisation.\n\nWe have granted your request to have it included in our directory.\n\nDetails of your organisation are now live in our directory."
-  expect_email_exists(message: message, email: email)
-end
-
 Then(/^an email should be sent to "(.*?)" as notification of the signup by email "(.*?)"$/) do |email, user_email|
   message = "A new user with the email #{user_email} has signed up on Harrow Community Network."
   expect_email_exists(message: message,email: email)

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -1,5 +1,4 @@
 Given(/^the following proposed organisations exist:$/) do |table|
-  require 'boolean'
   table.hashes.each do |hash|
     create_hash = {}
     proposer = nil
@@ -14,6 +13,35 @@ Given(/^the following proposed organisations exist:$/) do |table|
     proposed_org = ProposedOrganisation.new create_hash
     proposed_org.users << proposer if proposer
     proposed_org.save!
+  end
+end
+
+Given /^I accept a proposed organisation called "(.*?)" with email "(.*?)"$/ do |name, email|
+  steps %{
+    Given the following proposed organisations exist:
+      | name    | description         | address        | postcode | telephone | website            | email    | donation_info        | non_profit |
+      | #{name} | Mourning loved ones | 30 pinner road | HA5 4HZ  | 520800000 | http://#{name}.org | #{email} | www.pleasedonate.com | true       |
+    When I accept the proposed_organisation named "#{name}"
+  }
+end
+
+Then /^"(.*?)" is (notified|invited|ignored) as an organisation admin of "(.*?)"$/ do |email, action, name|
+  case action
+  when 'notified'
+    steps %{
+      Then an email should be sent to "#{email}" as notification of the acceptance of proposed organisation "#{name}"
+      And "#{email}" is an organisation admin of "#{name}"
+    }
+  when 'invited'
+    steps %{
+      Then an invitational email should be sent to "#{email}" as notification of the acceptance of proposed organisation "#{name}"
+      And "#{email}" is an organisation admin of "#{name}"
+    }
+  when 'ignored'
+    steps %{
+      Then "#{email}" is not an organisation admin of "#{name}"
+    }
+  else raise "unknown action '#{action}'"
   end
 end
 

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -34,7 +34,7 @@ def expect_proposed_org_is_invited(acceptance_message, email, org)
   expect(org.users.pluck(:email)).to include(email)
 end
 
-def expect_proposed_org_is_ignored(email, org)
+def expect_proposed_org_is_ignored(_, email, org)
   expect(org.users.pluck(:email)).not_to include(email)
 end
 
@@ -47,15 +47,7 @@ Then /^"(.*?)" is (notified|invited|ignored) as an organisation admin of "(.*?)"
 
   Details of your organisation are now live in our directory.
   MSG
-  case action
-  when 'notified'
-    expect_proposed_org_is_notified(acceptance_message, email, org)
-  when 'invited'
-    expect_proposed_org_is_invited(acceptance_message, email, org)
-  when 'ignored'
-    expect_proposed_org_is_ignored(email, org)
-  else raise "unknown action '#{action}'"
-  end
+  send("expect_proposed_org_is_#{action}", acceptance_message, email, org)
 end
 
 Given(/^a proposed organisation has been proposed by "(.*)"$/) do |user_email|

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -17,6 +17,7 @@ When /^I visit the proposed organisation show page for the proposed organisation
   proposed_org = ProposedOrganisation.find_by(name: unsaved_proposed_organisation(User.first).name)
   visit proposed_organisation_path(proposed_org)
 end
+
 When(/^I visit "(.*?)"$/) do |path|
   visit path
 end


### PR DESCRIPTION
I need one more PR merged for my [Hacktoberfest t-shirt](https://hacktoberfest.digitalocean.com/), so I figured it would be best to pick a story that has no user-facing impact and is safe to merge before November 1.

https://www.pivotaltracker.com/n/projects/742821/stories/105829888

This story picks up on a conversation thread Michael and Sam were having over [here](https://github.com/AgileVentures/LocalSupport/pull/188) about how to make some cucumber scenarios read more declaratively. Sam suggested refactoring four different but similar scenarios into one scenario outline.
