### PR TITLE
correct spacing on buttons which  looked odd

### DIFF
--- a/app/assets/stylesheets/organisations.css.scss
+++ b/app/assets/stylesheets/organisations.css.scss
@@ -111,7 +111,11 @@
 }
 
 #org-cat-buttons {
-  margin-top: 30px
+    margin-top: 30px;
+    .btn{
+        padding: 8px;
+        margin-bottom: 10px;
+    }
 }
 
 
@@ -141,5 +145,3 @@
   @extend .error;
   margin-bottom: -5px;
 }
-
-


### PR DESCRIPTION
PT link: https://www.pivotaltracker.com/story/show/141611529
The button spacing on the organisation looked a bit odd without proper spacing
<img width="300" alt="screenshot 2017-03-13 16 00 18" src="https://cloud.githubusercontent.com/assets/584211/24597440/8f404be0-184e-11e7-9b61-3b9138500977.png">

After adding spacing to the buttons this is how it looks like
![screenshot from 2017-04-03 09-18-14](https://cloud.githubusercontent.com/assets/584211/24597429/810eb304-184e-11e7-97a8-77b57ec74186.png)
