### PR TITLE
disable rubocop and codeclimate to always use &&, || and !

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ engines:
   rubocop:
     enabled: true
     config:
-      file: rubocop.yml
+      file: .rubocop.yml
 ratings:
   paths:
   - Gemfile.lock

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,6 +22,8 @@ engines:
     enabled: true
   rubocop:
     enabled: true
+    config:
+      file: rubocop.yml
 ratings:
   paths:
   - Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,7 @@ Style/Alias:
 Style/AndOr:
   Description: 'Use &&/|| instead of and/or.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-and-or-or'
-  Enabled: true
+  Enabled: false # See https://github.com/AgileVentures/LocalSupport/pull/455#issuecomment-307068564
 
 Style/ArrayJoin:
   Description: 'Use Array#join instead of Array#*.'
@@ -349,7 +349,7 @@ Style/NonNilCheck:
 Style/Not:
   Description: 'Use ! instead of not.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bang-not-not'
-  Enabled: true
+  Enabled: false # See https://github.com/AgileVentures/LocalSupport/pull/455#issuecomment-307068564
 
 Style/NumericLiterals:
   Description: >-


### PR DESCRIPTION
1. Fixes https://www.pivotaltracker.com/story/show/146910579
2. Configure codeclimate to follow `.rubocop.yml` configuration