### PR TITLE
Handle map info for organizations with empty latitude and longitude

### DIFF
--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -84,15 +84,22 @@ function openInfoBox(coordinates) {
 
 google.maps.event.addDomListener(window, "load", initMap);
 
+var debouceOpenInfoBox = _.debounce(function(volop) {
+    if ($(volop).attr('data-lat') != '' && $(volop).attr('data-lng') != '') {
+      centerMap(getVolOpCoordinates(volop));
+      openInfoBox(getVolOpCoordinates(volop));
+    }
+}, 300);
+
 $(document).ready(function() {
   if (($('#content').height() - 14) >= 400) {
     $('#map-canvas').height($('#content').height() - 14);
   }
-  
-  $('.center-map-on-op').mouseenter(function() {
-    centerMap(getVolOpCoordinates(this));
-    openInfoBox(getVolOpCoordinates(this));
-  }).mouseleave(function() {
+
+  $('.center-map-on-op').mouseenter(function () {
+    debouceOpenInfoBox(this);
+  })
+  .mouseleave(function() {
     closeInfoBox();
   });
 });

--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -85,7 +85,7 @@ function openInfoBox(coordinates) {
 google.maps.event.addDomListener(window, "load", initMap);
 
 var debouceOpenInfoBox = _.debounce(function(volop) {
-    if ($(volop).attr('data-lat') != '' && $(volop).attr('data-lng') != '') {
+    if ($(volop).attr('data-lat') !== '' && $(volop).attr('data-lng') !== '') {
       centerMap(getVolOpCoordinates(volop));
       openInfoBox(getVolOpCoordinates(volop));
     }


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/149238445

- Avoid showing map info box for organizations with empty latitude and longitude
- Use debounced version of the function that show organization info on the map, to avoid performance issues when the user scrolls fast over the list