### PR TITLE
Update qt instructions in os mac install docs

### DIFF
--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -13,8 +13,8 @@ Install Homebrew (if you don't have it already). If you do have Homebrew, run `b
 This will allow you to install capybara-webkit -v '1.0.0' successfully.
 If you are still unable to successfully install the caybara-webkit try the following.  First `brew uninstall qt@5.5` to uninstall previous installation, then re-install using 
 `brew install qt@5.5 --with-qtwebkit`, and finally `brew link qt@5.5`. 
-You may also need to update your paths. If using standard bash `echo 'export PATH="/usr/local/opt/qt@5.5/bin:$PATH"' >> ~/.zshrc`, or if using zsh 
-`echo 'export PATH="/usr/local/opt/qt@5.5/bin:$PATH"' >> ~/.bashrc`
+You may also need to update your paths. If using standard bash `echo 'export PATH="/usr/local/opt/qt@5.5/bin:$PATH"' >> ~/.bashrc`, or if using zsh 
+`echo 'export PATH="/usr/local/opt/qt@5.5/bin:$PATH"' >> ~/.zshrc`
 1. Install postgreSQL.
 Type `psql` into command line. Then you should see this:
 

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -11,6 +11,10 @@ In order to work on LocalSupport on Mac, please fork and clone the project.
 1. Install Qt webkit headers.
 Install Homebrew (if you don't have it already). If you do have Homebrew, run `brew update` and after brew is installed or updated, type `brew install qt@5.5`
 This will allow you to install capybara-webkit -v '1.0.0' successfully.
+If you are still unable to successfully install the caybara-webkit try the following.  First `brew uninstall qt@5.5` to uninstall previous installation, then re-install using 
+`brew install qt@5.5 --with-qtwebkit`, and finally `brew link qt@5.5`. 
+You may also need to update your paths. If using standard bash `echo 'export PATH="/usr/local/opt/qt@5.5/bin:$PATH"' >> ~/.zshrc`, or if using zsh 
+`echo 'export PATH="/usr/local/opt/qt@5.5/bin:$PATH"' >> ~/.bashrc`
 1. Install postgreSQL.
 Type `psql` into command line. Then you should see this:
 


### PR DESCRIPTION
Add further steps to install the Qt webkit headers if installation of capybara-webkit still fails following `brew install qt@5.5`.