### PR TITLE
84261430 - Volunteer Op update button has incorrect text

### DIFF
--- a/app/helpers/volunteer_ops_helper.rb
+++ b/app/helpers/volunteer_ops_helper.rb
@@ -1,6 +1,6 @@
 module VolunteerOpsHelper
   def button_text object
-    object.new_record? ? 'Create a Volunteer Opportunity' : 'Update a Volunteer Opportunity'
+    object.new_record? ? 'Create a Volunteer Opportunity' : 'Update Volunteer Opportunity'
   end
 
   def link_to_vol_op(obj, type, html_options = {})

--- a/features/step_definitions/volunteer_op_steps.rb
+++ b/features/step_definitions/volunteer_op_steps.rb
@@ -88,7 +88,7 @@ Given /^I update "(.*?)" volunteer op description to be "(.*?)"$/ do |title, des
   visit volunteer_op_path vop
   click_on 'Edit'
   fill_in('Description', :with => description)
-  click_on 'Update a Volunteer Opportunity'
+  click_on 'Update Volunteer Opportunity'
 end
 
 Given /^I should see (\d+) markers in the map$/ do |num|
@@ -102,7 +102,7 @@ end
 When(/^I set new volunteer opportunity location to "(.*?)", "(.*?)"$/) do |addr, pc|
   fill_in 'Address', with: addr
   fill_in 'Postcode', with: pc
-  click_button 'Update a Volunteer Opportunity'
+  click_button 'Update Volunteer Opportunity'
 end
 
 regex = /^I should see "(.*?)", "(.*?)", "(.*?)" and "(.*?)"$/

--- a/spec/helpers/volunteer_ops_helper_spec.rb
+++ b/spec/helpers/volunteer_ops_helper_spec.rb
@@ -11,7 +11,7 @@ describe VolunteerOpsHelper, :type => :helper do
 
     it 'button mentions "Update" when it is NOT a new record' do
       allow(op).to receive_messages new_record?: false
-      expect(button_text(op)).to eq 'Update a Volunteer Opportunity'
+      expect(button_text(op)).to eq 'Update Volunteer Opportunity'
     end
 
     it 'mutation-proofing' do


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/84261430

Should say "Update Volunteer Opportunity," but says "Update a Volunteer Opportunity."
