### PR TITLE
151878364 Fix mixed content warning

### DIFF
--- a/app/views/shared/_map_scripts.html.erb
+++ b/app/views/shared/_map_scripts.html.erb
@@ -1,5 +1,5 @@
 <% content_for :scripts do %>
-  <script src="//maps.google.com/maps/api/js?v=3&amp;libraries=geometry<%= gmap_key_value_for_url %>" type="text/javascript"></script>
+  <script src="https://maps.google.com/maps/api/js?v=3&amp;libraries=geometry<%= gmap_key_value_for_url %>" type="text/javascript"></script>
   <%= javascript_include_tag 'maps' %>
 <% end %>
 

--- a/app/views/volunteer_ops/embedded_map.erb
+++ b/app/views/volunteer_ops/embedded_map.erb
@@ -18,7 +18,7 @@
   <![endif]-->
   <script src="/assets/jquery.js?body=1"></script>
   <script src="/assets/underscore.js?body=1"></script>
-  <script src="//maps.google.com/maps/api/js?v=3&amp;libraries=geometry<%= gmap_key_value_for_url %>" type="text/javascript"></script>
+  <script src="https://maps.google.com/maps/api/js?v=3&amp;libraries=geometry<%= gmap_key_value_for_url %>" type="text/javascript"></script>
   <%= javascript_include_tag 'maps' %>
 </head>
 

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -187,7 +187,7 @@ And(/^"(.*?)" should not have nil coordinates$/) do |name|
   org.longitude.should_not be_nil
 end
 
-GMAPS_URL_KEY_NIL = '//maps.google.com/maps/api/js?' +
+GMAPS_URL_KEY_NIL = 'https://maps.google.com/maps/api/js?' +
                     'v=3&libraries=geometry&key='.freeze
 
 Then(/^the google map key should( not)? be appended to the gmap js script$/) do |negation|


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/151878364

When viewing the volunteer map on Local Support the following warning about mixing secure and unsecure content is raised in the javascript console

![](https://dl.dropboxusercontent.com/s/0bjwcj0nad9d18q/Harrow_Community_Network___Harrow_volunteering.png?dl=0)