### PR TITLE
85129350 Fixes flash success style

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,7 @@ module ApplicationHelper
     case flash_type
     when 'warning'
       'alert-warning'
-    when 'notice'
+    when 'notice', 'success'
       'alert-success'
     else
       'alert-danger'

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -203,7 +203,7 @@ Then(/^I should see "([^"]*)" in the flash error$/) do |message|
 end
 
 Then(/^I should see "([^"]*)" in the flash$/) do |message|
-  page.should have_css('div#flash_success', :text => message)
+  page.should have_css('div#flash_success.alert-success', :text => message)
 end
 
 Then(/^I should( not)? see the call to update details for organisation "(.*)"/) do |negative, org_name|


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/85129350

Fixes flash[:success] which is incorrectly styled as red
