### PR TITLE
Building coordinates with the results of the query.

### DIFF
--- a/app/controllers/volunteer_ops_controller.rb
+++ b/app/controllers/volunteer_ops_controller.rb
@@ -7,9 +7,10 @@ class VolunteerOpsController < ApplicationController
 
   def search
     @query = params[:q]
-    @volunteer_ops = VolunteerOp.order_by_most_recent.search_for_text(@query)
+    @volunteer_ops = VolunteerOp.order_by_most_recent.search_for_text(@query).to_a
     flash.now[:alert] = SEARCH_NOT_FOUND if @volunteer_ops.empty?
-    @markers = BuildMarkersWithInfoWindow.with(VolunteerOp.build_by_coordinates, self)
+    @markers = BuildMarkersWithInfoWindow
+      .with(VolunteerOp.build_by_coordinates(@volunteer_ops), self)
     render template: 'volunteer_ops/index'
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -6,13 +6,13 @@ class Location
     @longitude = longitude
     @latitude = latitude
   end
-  
+
   def ==(other)
     self.class == other.class &&
       self.longitude == other.longitude &&
       self.latitude == other.latitude
   end
-  
+
   alias eql? ==
 
 

--- a/app/models/volunteer_op.rb
+++ b/app/models/volunteer_op.rb
@@ -15,11 +15,11 @@ class VolunteerOp < ActiveRecord::Base
   scope :doit,                 -> { where(source: 'doit') }
   scope :reachskills,          -> { where(source: 'reachskills') }
   scope :remote_only,          -> { where.not(source: 'local') }
-  
+
   def self.add_coordinates(vol_ops)
     vol_op_with_coordinates(vol_ops)
   end
-  
+
   def full_address
     "#{self.address}, #{self.postcode}"
   end
@@ -55,11 +55,15 @@ class VolunteerOp < ActiveRecord::Base
     arel_table[:title].matches(text)
   end
 
-  def self.build_by_coordinates
-    local_vol_ops = vol_op_with_coordinates(VolunteerOp.local_only)
-    vol_ops = local_vol_ops + VolunteerOp.remote_only
-    vol_op_by_coordinates = group_by_coordinates(vol_ops)
-    Location.build_hash(vol_op_by_coordinates)
+  def self.build_by_coordinates(opts=nil)
+    if opts.nil?
+      local_vol_ops = vol_op_with_coordinates(VolunteerOp.local_only)
+      vol_ops = local_vol_ops + VolunteerOp.remote_only
+      vol_op_by_coordinates = group_by_coordinates(vol_ops)
+      return Location.build_hash(vol_op_by_coordinates)
+    end
+    vol_op_by_coordinates = group_by_coordinates(opts)
+    return Location.build_hash(vol_op_by_coordinates)
   end
 
   def address_complete?
@@ -75,7 +79,7 @@ class VolunteerOp < ActiveRecord::Base
   end
 
   private
-  
+
   def clear_lat_lng
     return if address_complete?
     self.longitude = nil


### PR DESCRIPTION
- We are building coordinates only with the results of the query;
- Removed white spaces on Location class and VolunteerOp model;
- Class method `build_by_coordinates` is now receiving an optional parameter (those parameters are the result of the query);