### PR TITLE
153138574 remove variable not being used

### DIFF
--- a/app/controllers/volunteer_ops_controller.rb
+++ b/app/controllers/volunteer_ops_controller.rb
@@ -21,7 +21,6 @@ class VolunteerOpsController < ApplicationController
   def show
     render template: 'pages/404', status: 404 and return if @volunteer_op.nil?
     @organisation = Organisation.friendly.find(@volunteer_op.organisation_id)
-    organisations = Organisation.where(id: @organisation.id)
     @editable = current_user.can_edit?(@organisation) if current_user
     @markers = BuildMarkersWithInfoWindow.with(VolunteerOp.build_by_coordinates, self)
     add_breadcrumb @organisation.name, organisation_path(@organisation)


### PR DESCRIPTION
On "VolunteerOpsController" in `show` method, `organizations` variable is being created and is never used.