### PR TITLE
153370923 - Remove "Fixnum" deprecation warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem 'database_cleaner', '1.0.1'
   gem 'launchy'
   gem 'simplecov'
-  gem 'sinatra-base'
+  gem 'sinatra'
   gem 'rspec-rails'
   gem 'rspec-activemodel-mocks'
   gem 'execjs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,10 +364,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra-base (1.4.0)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
-      tilt (~> 1.3, >= 1.3.3)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -480,7 +480,7 @@ DEPENDENCIES
   shoulda
   show_me_the_cookies
   simplecov
-  sinatra-base
+  sinatra
   sprockets (~> 2.11, >= 2.11.3)
   sucker_punch (~> 2.0)
   therubyracer


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/153370923

@tansaku this will remove the `Fixnum` deprecation warnings on our rspec tests, but it wont close the task on Pivotal Tracker because we need to remove also the deprecation warnings that the datepicker is generating while running cucumber.