### PR TITLE
153481608 refactor import doit heroku daily job

### DIFF
--- a/app/models/volunteer_op.rb
+++ b/app/models/volunteer_op.rb
@@ -15,11 +15,11 @@ class VolunteerOp < ActiveRecord::Base
   scope :doit,                 -> { where(source: 'doit') }
   scope :reachskills,          -> { where(source: 'reachskills') }
   scope :remote_only,          -> { where.not(source: 'local') }
-  
+
   def self.add_coordinates(vol_ops)
     vol_op_with_coordinates(vol_ops)
   end
-  
+
   def full_address
     "#{self.address}, #{self.postcode}"
   end
@@ -77,8 +77,13 @@ class VolunteerOp < ActiveRecord::Base
     source
   end
 
+  def new_volop?
+    one_day_ago = Time.now - 1.day
+    created_at > one_day_ago
+  end
+
   private
-  
+
   def clear_lat_lng
     return if address_complete?
     self.longitude = nil

--- a/app/models/volunteer_op.rb
+++ b/app/models/volunteer_op.rb
@@ -78,7 +78,7 @@ class VolunteerOp < ActiveRecord::Base
   end
 
   def new_volop?
-    one_day_ago = Time.now - 1.day
+    one_day_ago = Time.current - 1.day
     created_at > one_day_ago
   end
 

--- a/app/models/volunteer_op.rb
+++ b/app/models/volunteer_op.rb
@@ -77,7 +77,7 @@ class VolunteerOp < ActiveRecord::Base
     source
   end
 
-  def new_volop?
+  def new?
     one_day_ago = Time.current - 1.day
     created_at > one_day_ago
   end

--- a/app/services/import_do_it_volunteer_opportunities.rb
+++ b/app/services/import_do_it_volunteer_opportunities.rb
@@ -48,6 +48,7 @@ class ImportDoItVolunteerOpportunities
         model.doit_org_name = op['for_recruiter']['name']
         model.doit_org_link = op['for_recruiter']['slug']
         model.updated_at = op['updated']
+        model.created_at = op['created']
       end
     end
   end

--- a/spec/models/volunteer_op_spec.rb
+++ b/spec/models/volunteer_op_spec.rb
@@ -310,4 +310,19 @@ describe VolunteerOp, type: :model do
       expect(VolunteerOp.get_source([l_vol_op1, d_vol_op2])).to eq('mixed')
     end
   end
+
+  describe 'a new volunteer opportunity' do
+    context 'is new volunteer opportunity' do
+      it 'returns true' do
+        new_volop = build(:volunteer_op, created_at: Time.now)
+        expect(new_volop.new_volop?).to be_truthy
+      end
+    end
+    context 'is not new volunteer opportunity' do
+      it 'returns false' do
+        not_new_volop = build(:volunteer_op, created_at: Time.now - 1.day)
+        expect(not_new_volop.new_volop?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/models/volunteer_op_spec.rb
+++ b/spec/models/volunteer_op_spec.rb
@@ -314,13 +314,13 @@ describe VolunteerOp, type: :model do
   describe 'a new volunteer opportunity' do
     context 'is new volunteer opportunity' do
       it 'returns true' do
-        new_volop = build(:volunteer_op, created_at: Time.now)
+        new_volop = build(:volunteer_op, created_at: Time.current)
         expect(new_volop.new_volop?).to be_truthy
       end
     end
     context 'is not new volunteer opportunity' do
       it 'returns false' do
-        not_new_volop = build(:volunteer_op, created_at: Time.now - 1.day)
+        not_new_volop = build(:volunteer_op, created_at: Time.current - 1.day)
         expect(not_new_volop.new_volop?).to be_falsey
       end
     end

--- a/spec/models/volunteer_op_spec.rb
+++ b/spec/models/volunteer_op_spec.rb
@@ -169,7 +169,7 @@ describe VolunteerOp, type: :model do
     end
   end
 
-  describe '#address_compelete?' do
+  describe '#address_complete?' do
     context 'volunteer op has address and postcode' do
       it 'returns true' do
         vol_op = build(:volunteer_op, address: 'not nil', postcode: 'HA1 4HZ')
@@ -311,14 +311,14 @@ describe VolunteerOp, type: :model do
     end
   end
 
-  describe 'a new volunteer opportunity' do
-    context 'is new volunteer opportunity' do
+  describe '#new?' do
+    context 'a volunteer opportunity created in the last day' do
       it 'returns true' do
         new_volop = build(:volunteer_op, created_at: Time.current)
         expect(new_volop).to be_new
       end
     end
-    context 'is not new volunteer opportunity' do
+    context 'a volunteer opportunity created more than a day ago' do
       it 'returns false' do
         old_volop = build(:volunteer_op, created_at: Time.current - 1.day)
         expect(old_volop).not_to be_new

--- a/spec/models/volunteer_op_spec.rb
+++ b/spec/models/volunteer_op_spec.rb
@@ -315,13 +315,13 @@ describe VolunteerOp, type: :model do
     context 'is new volunteer opportunity' do
       it 'returns true' do
         new_volop = build(:volunteer_op, created_at: Time.current)
-        expect(new_volop.new_volop?).to be_truthy
+        expect(new_volop).to be_new
       end
     end
     context 'is not new volunteer opportunity' do
       it 'returns false' do
-        not_new_volop = build(:volunteer_op, created_at: Time.current - 1.day)
-        expect(not_new_volop.new_volop?).to be_falsey
+        old_volop = build(:volunteer_op, created_at: Time.current - 1.day)
+        expect(old_volop).not_to be_new
       end
     end
   end


### PR DESCRIPTION
When opportunities are imported from doit they come with a 'created' date for each opportunity in the response file. We can use that created date instead of the default date when importing all opportunities into our database that way we can ask an opportunity if it is new.

Fixes issue [153481608](https://www.pivotaltracker.com/story/show/153481608)