### PR TITLE
153813738 - Using regex to match 'Error' or 'error' starting with space.

### DIFF
--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -567,7 +567,8 @@ end
 
 Given(/^I can run the rake task "(.*?)"$/) do |task|
   stdout, stderr, status = Open3.capture3("#{task}")
-  expect(stderr).not_to include "Error"
+  # match word 'Error' or 'error' starting with space.
+  expect(stderr).not_to match /\s\b(Error)\b/ix
   expect(status).to be_success
 end
 


### PR DESCRIPTION
I'm doing this since the deprecating warning triggered by the upgrade of 'pg' gem is making our tests fail, since is using PG::Error on the deprecation message.

https://www.pivotaltracker.com/story/show/153813738