### PR TITLE
154083107 - Removed deprecated gem 'quiet_assets'.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,6 @@ group :development do
   gem 'rubocop-git'
   gem 'letter_opener'
   gem 'railroady'
-  gem 'quiet_assets'
-
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,8 +267,6 @@ GEM
       eventmachine_httpserver
       http_parser.rb (~> 0.6.0)
       multi_json
-    quiet_assets (1.1.0)
-      railties (>= 3.1, < 5.0)
     rack (1.6.8)
     rack-protection (1.5.3)
       rack
@@ -477,7 +475,6 @@ DEPENDENCIES
   phantomjs
   poltergeist
   puffing-billy
-  quiet_assets
   rack_session_access
   railroady
   rails (~> 4.2, >= 4.2.7.1)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/154083107

## Deprecation
As of sprockets-rails version 3.1.0, used in current versions of rails, this gem is deprecated.

The asset pipeline now supports a quiet option which suppresses output of asset requests:

### config/environments/development.rb

config.assets.quiet = true
Relevant PR: https://github.com/rails/sprockets-rails/pull/355