### PR TITLE
Fix embedded map display

### DIFF
--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -85,8 +85,8 @@ var OrganisationMap = {
     }
   },
   init: function init() {
-    if (window.innerWidth <= 1024) {
-        $('#map-canvas').height(window.innerHeight - 300);
+    if (($('#content').height() - 14) >= 400) {
+      $('#map-canvas').height($('#content').height() - 14);
     }
 
       // _.debounce(function() {


### PR DESCRIPTION
Reverted the map display to it's prior dimensions.

The embedded map on VoluntaryActionHarrow is using a size that is less
than 300 and since the change was subtracting 300 from it's size the map 
being displayed was too small to see.