### PR TITLE
WIP_150890866 skip null map markers

### DIFF
--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -32,6 +32,7 @@ var OrganisationMap = {
     ibOptions.content = boxText;
 
     markerData.forEach(function(item) {
+      if (!(item.lat && item.lng)) return;
       var latLng = new google.maps.LatLng(item.lat, item.lng);
 
       marker = new CustomMarker(

--- a/app/services/import_reach_skills_volunteer_opportunities.rb
+++ b/app/services/import_reach_skills_volunteer_opportunities.rb
@@ -50,8 +50,8 @@ class ImportReachSkillsVolunteerOpportunities
 
   def populate_vol_op_attributes(op, model, coordinates)
     model.source = 'reachskills'
-    model.latitude = coordinates ? coordinates.latitude.to_f : 0.0
-    model.longitude = coordinates ? coordinates.longitude.to_f : 0.0
+    model.latitude = coordinates ? coordinates.latitude.to_f : nil
+    model.longitude = coordinates ? coordinates.longitude.to_f : nil
     model.title = op['node']['title']
     model.description = op['node']['Description']
     model.reachskills_org_name = op['node']['Organisation']


### PR DESCRIPTION
Skip creation of a custom marker when the latitude and longitude coordinates are null, and persist lat/long coordinates that are valid.
https://www.pivotaltracker.com/story/show/150890866