### PR TITLE
Remove Pages Helper

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,2 +1,0 @@
-module PagesHelper
-end


### PR DESCRIPTION
The module app/helpers/pages_helper.rb was created but is not being used anywhere and it should be removed.