### PR TITLE
Remove merge_in_non_published_fields

### DIFF
--- a/app/services/create_proposed_organisation_edit.rb
+++ b/app/services/create_proposed_organisation_edit.rb
@@ -20,20 +20,12 @@ class CreateProposedOrganisationEdit
 
   def run
     unless editor.siteadmin?
-      merge_in_non_published_fields
       send_email_to_superadmin_about_org_edit
       listener.set_notice('Edit is pending admin approval.')
     end
     model_klass.create(params)
   end
-
-  def merge_in_non_published_fields
-    in_memory_edit = ProposedOrganisationEdit.new(organisation: organisation)
-    in_memory_edit.non_published_generally_editable_fields.each do |non_published_field|
-      params.merge!(non_published_field => organisation.send(non_published_field))
-    end
-  end
-
+  
   def send_email_to_superadmin_about_org_edit
     superadmin_emails = user_klass.superadmin_emails
     mailing = mailer_klass.edit_org_waiting_for_approval(organisation, superadmin_emails)

--- a/app/views/proposed_organisation_edits/_form.html.erb
+++ b/app/views/proposed_organisation_edits/_form.html.erb
@@ -31,6 +31,8 @@
           <input type="checkbox" disabled class="publish" <%= checked="checked" if @proposed_organisation_edit.viewable_field?(:address) %> value="" class="publish">
         </td>
       </tr>
+      <% else %>
+        <%= f.hidden_field :address, :value => @proposed_organisation_edit[:address] %>
       <% end %>
       <tr>
         <td class="borderless" data-toggle="tooltip" title="Make sure post code is accurate">
@@ -49,6 +51,8 @@
           <input type="checkbox" disabled class="publish" <%= checked="checked" if @proposed_organisation_edit.viewable_field?(:email) %> value="" class="publish">
         </td>
       </tr>
+      <% else %>
+        <%= f.hidden_field :email, :value => @proposed_organisation_edit[:email] %>
       <% end %>
       <tr>
         <td class="borderless" data-toggle="tooltip" title="Make sure url is correct">
@@ -67,6 +71,8 @@
           <input type="checkbox" disabled class="publish" <%= checked="checked" if @proposed_organisation_edit.viewable_field?(:telephone) %> value="" class="publish">
         </td>
       </tr>
+      <% else %>
+        <%= f.hidden_field :telephone, :value => @proposed_organisation_edit[:telephone] %>
       <% end %>
       <tr>
         <td class="borderless" data-toggle="tooltip" title="Please enter a website here either to the fundraising page on your website or to an online donation site.">

--- a/features/organisations/proposed_organisation_edits.feature
+++ b/features/organisations/proposed_organisation_edits.feature
@@ -1,0 +1,25 @@
+Feature: Propose edits to organisation
+  
+  
+  Background: organisations have been added to database
+
+    Given the following organisations exist:
+      | name                | description      | address        | postcode | website       | publish_address |
+      | Elders Association  | For the elderly  | 64 pinner road | HA1 4HZ  | http://b.com/ | false           |
+    
+  
+  Scenario: Users should not see organisation's non-published fields
+    Given that I am logged in as any user
+    When I visit "Elders Association" organisation page
+    Then I should see "HA1 4HZ"
+    And I should not see "64 pinner road"
+    
+  Scenario: Propose edits to another organisation as a regular user
+    Given that I am logged in as any user
+    And I visit "Elders Association" organisation propose edit page
+    When I fill in "proposed_organisation_edit_description" with "Care for the elderly" within the main body
+    And I fill in "proposed_organisation_edit_postcode" with "HA1" within the main body
+    And I press "Propose this edit"
+    Then I should see "Edit is pending admin approval."
+    And I should see "Care for the elderly" within "proposed_organisation_description" field
+    And I should see "HA1" within "proposed_organisation_postcode" field

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -371,6 +371,10 @@ Then(/^the navbar should( not)? have a link to (.*?)$/) do |negate, link|
   within('#navbar') { expect(page).send(expectation_method, have_selector(:link_or_button, link)) }
 end
 
+Then(/^I should see "(.*?)" within "(.*?)" field$/) do |text, selector|
+  within('.' + selector) { expect(page).to have_content text}
+end
+
 Then(/^I should not see "(.*?)"  within "(.*?)"$/) do |text, selector|
   within('.' + selector) { expect(page).not_to have_content text}
 end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -231,3 +231,13 @@ end
 When(/^I click column header "([^"]*)"$/) do |val|
   find('th', :text => val).click()
 end
+
+Given("I visit {string} organisation page") do |name|
+  id = Organisation.find_by(name: name).id
+  visit organisation_path(:id => id)
+end
+
+Given("I visit {string} organisation propose edit page") do |name|
+  id = Organisation.find_by(name: name).id
+  visit new_organisation_proposed_organisation_edit_path :organisation_id => id
+end

--- a/spec/requests/propose_edits_spec.rb
+++ b/spec/requests/propose_edits_spec.rb
@@ -17,7 +17,7 @@ describe 'Propose an edit', type: :request, helpers: :requests do
   it 'non-published fields are copied into proposed org edit' do
     expect(ProposedOrganisationEdit.still_pending).to be_empty
     post organisation_proposed_organisation_edits_path(proposed_edit.organisation),
-      params: {proposed_organisation_edit: {name: 'Different Name'}}
+      params: {proposed_organisation_edit: {name: 'Different Name', address: '34 pinner road', telephone: '202', email: 'blah@blah.org'}}
     edit = ProposedOrganisationEdit.still_pending.reorder(updated_at: :desc).first
     expect(edit.address).to eq '34 pinner road'
     expect(edit.telephone).to eq '202'

--- a/spec/services/create_proposed_organisation_edit_spec.rb
+++ b/spec/services/create_proposed_organisation_edit_spec.rb
@@ -25,14 +25,8 @@ describe CreateProposedOrganisationEdit do
 
     before do
       allow(listener).to receive_message_chain :flash, :[]=
-      allow_any_instance_of(described_class).to receive :merge_in_non_published_fields
       allow(user_klass).to receive(:superadmin_emails).and_return(:admins)
       allow(mailer_class).to receive_message_chain :edit_org_waiting_for_approval, :deliver_now
-    end
-
-    it 'merges in non published fields' do
-      expect_any_instance_of(described_class).to receive :merge_in_non_published_fields
-      create_proposed_organisation_edit
     end
 
     it 'sends email to superadmin about org edit' do


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/n/projects/742821/stories/112152187
1. Removed the merge_in_non_published_fields method that was adding missing fields from the model and replaced it with code to fetch the missing data directly from the views.
2. Added cucumber tests and changed the related existing rspec tests.