### PR TITLE
logging in from /events/new should return user to /events/new

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
         organisations
         pages
         volunteer_ops
+        events
     )
   end
   # Devise wiki suggests we need to make this return nil for the

--- a/features/sign_in_sign_up/sign_in.feature
+++ b/features/sign_in_sign_up/sign_in.feature
@@ -55,7 +55,7 @@ Scenario: Sign in for an existing superadmin user after org search
   Then I should be on the organisations search page
   And I should see a link or button "superadmin@example.com"
   And the search box should contain "search words"
-  
+
 Scenario: Sign in for an existing superadmin user after vol op search
   Given I visit the volunteer opportunities page
   And I fill in "Search Text" with "search words" within the main body
@@ -69,6 +69,12 @@ Scenario: Sign in for an existing superadmin user after visit vol op page
   Given I visit the show page for the volunteer_op titled "Office Support"
   And I sign in as "superadmin@example.com" with password "pppppppp"
   Then I should be on the show page for the volunteer_op titled "Office Support"
+  And I should see a link or button "superadmin@example.com"
+
+Scenario: Sign in for an existing superadmin after visit new event page
+  Given I visit the new event page
+  And I sign in as "superadmin@example.com" with password "pppppppp" on the legacy sign in page
+  Then I should be on the new event page
   And I should see a link or button "superadmin@example.com"
 
 Scenario: Sign in with wrong password for an existing superadmin user


### PR DESCRIPTION
the solution is add events to whitelist.
now auto redirect after signing in is working correctly for events/new

Addresses: https://www.pivotaltracker.com/n/projects/742821/stories/157115541