### PR TITLE
implement outbound click tracking using google analytics 

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -5,3 +5,16 @@
 
 ga('create', 'UA-60361269-1', 'auto');
 ga('send', 'pageview');
+
+var trackOutboundLink = function(url, isExternal) {
+    var params = {};
+
+    if (!isExternal) {
+        params.hitCallback = function () {
+            document.location = url;
+        }
+    }
+    ga('send', 'event', 'outbound', 'click', url, params);
+
+    return isExternal;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,7 +53,9 @@ module ApplicationHelper
 
   def link_to_and_track(title, url='#', options = {})
     options[:target] = '_blank' if action_name == 'embedded_map'
-    link_to title, click_through_go_path(url: url), options
+    is_external = options[:target] == '_blank' ? 'true' : 'false'
+    options[:onclick] = "return trackOutboundLink('#{url}', #{is_external})"
+    link_to title, url, options
   end
 end
 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -261,7 +261,7 @@ end
 
 Then /^the URL for "(.*?)" should refer to tracking link including "(.*?)"$/ do |name, href|
   link = find_link(name)
-  expect(link['href']).to include(CGI.escape(href))
+  expect(link['href']).to include(href)
 end
 
 And /^the search box should contain "(.*?)"$/ do |arg1|

--- a/features/step_definitions/volunteer_op_steps.rb
+++ b/features/step_definitions/volunteer_op_steps.rb
@@ -139,7 +139,7 @@ Then(/^I should see a link to "(.*?)" page "(.*?)"$/) do |link, url|
 end
 
 Then(/^I should see a tracking link to "(.*?)" page "(.*?)"$/) do |link, url|
-  page.should have_link(link, :href => "#{click_through_go_path}?url=#{CGI.escape(url)}")
+  page.should have_link(link, :href => "#{url}")
 end
 
 When(/^I set new volunteer opportunity location to "(.*?)", "(.*?)"$/) do |addr, pc|
@@ -183,13 +183,4 @@ Given(/^I fill additional fields required by Doit$/) do
   fill_in('Advertise start date', with: '2017-03-01')
   fill_in('Advertise end date', with: '2017-04-01')
 
-end
-
-Then(/^Opening "(.*?)" should update the click through table/) do |organisation|
-  expect { click_link(organisation) }.to change { ClickThrough.count }
-end
-
-Then (/^I should see "(.*?)" in the the click through table/) do |link|
-  sleep 0.1
-  expect(ClickThrough.last.url).to start_with(link)
 end

--- a/features/volunteer_opportunities/doit_volunteer_opportunities.feature
+++ b/features/volunteer_opportunities/doit_volunteer_opportunities.feature
@@ -47,6 +47,5 @@ Feature: Doit volunteer opportunities
   Scenario: Doit volunteer opportunities are opened in a new page
     Given I visit the volunteer opportunities page
     Then I should open "Scout Leader (volunteering with 10-14 year olds) 27th Harrow" in a new window
-    Then I should see "https://do-it.org/opportunities/79ae1022-9059-40c0-82dd-3f5b15dd796a" in the the click through table
 
 

--- a/features/volunteer_opportunities/reachskills_volunteer_opportunities.feature
+++ b/features/volunteer_opportunities/reachskills_volunteer_opportunities.feature
@@ -41,4 +41,3 @@ Feature: Reachskills volunteer opportunities
   Scenario: Reachskills volunteer opportunities are opened in a new page
     Given I visit the volunteer opportunities page
     Then I should open "Charity Treasurer" in a new window
-    Then I should see "https://reachskills.org.uk/opp/charity-treasurer-10" in the the click through table


### PR DESCRIPTION
[Finishes #156190282]

https://www.pivotaltracker.com/story/show/154185754

This PR implements the use google analytics to track outbound clicks.  

**Note:**  I feel this needs to be tested in production, then once we are happy that the click throughs are tracked in GA, I will then create a further pull request to remove the old click through code, implement migrations to remove the old tracking table etc.