### PR TITLE
Fix typos, update ruby version on README.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ Please start by creating an Application.yml file
 
 ### Application.yml
 
-Independently of which platform you are developing on please create a file named `config/application.yml` and add the following line:
+Independently of which platform you are developing on, please create a file named `config/application.yml` and add the following line:
 
 ```
 DOIT_HOST: 'http://api.qa2.do-it.org/v2'
@@ -33,7 +33,7 @@ Instructions for installation on different OSs:
 * [C9](installation/c9.md)
 * [Docker](installation/Developing-With-Docker.md)
 
-If you're on Windows, our condolences. Docker or C9 is probably your best option, however there are a variety of ways to install [Ubuntu](https://www.ubuntu.com/) while keeping your Windows OS instact if you willing.
+If you're on Windows, our condolences. Docker or C9 is probably your best option, however there are a variety of ways to install [Ubuntu](https://www.ubuntu.com/) while keeping your Windows OS intact if you are willing.
 
 Update: Windows 10 is beta testing a Linux subsystem. Find out how to install at [gorails](https://gorails.com/setup/windows/10). Please keep in mind it is still in beta as of this writing.
 

--- a/docs/installation/c9.md
+++ b/docs/installation/c9.md
@@ -61,7 +61,7 @@ sudo /etc/init.d/postgresql restart
 
     `sudo apt-get install xvfb`
 
-9. Run `bundle install` to get the gems (run `gem install bundle` if bundler is not installed)
+9. Run `bundle install` to get the gems (run `gem install bundler` if bundler is not installed)
 
  (*Note:* If your connection breaks during the process retry until all gems are installed.)
 
@@ -129,4 +129,3 @@ Execute the suggested command to install the proper version (the compilation of 
 You should also make that ruby version your default version, with the command:
 
 `rvm --default use 2.x.y`
-

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -5,7 +5,7 @@ In order to work on LocalSupport, please fork and clone the project.
 
 If you need to setup your development environment then [gorails](https://gorails.com/setup/ubuntu/17.10) has an excellent walkthrough.
 
-1. Install Ruby 2.4.2
+1. Install Ruby 2.5.0
 1. Fork the http://github.com/AgileVentures/LocalSupport repo (fork button at top right of github web interface)
 1. Clone the new forked repo onto your dev machine
 1. `cd LocalSupport`
@@ -30,6 +30,9 @@ If you need to setup your development environment then [gorails](https://gorails
   ```
 
 1. Install postgreSQL - see [PostgreSQL install instructions below](issues.md#postgresql-install)
+
+
+
 1. Install X virtual frame buffer
 
     `sudo apt-get install xvfb`
@@ -43,6 +46,18 @@ If you need to setup your development environment then [gorails](https://gorails
     bundle exec rake db:migrate
     bundle exec rake db:setup
     ```
+  *Note:*  You might encounter error with the creating the relevant schema. This is due to some configuration error with PostgreSql. Solution of interest can be found [(1) here](PostgreSQL-problems-in-Debian.md) and [(2) here](issues.md#peer-authentication-fails-for-user-postgres). You should first drop the cluster as mentioned in (1) and then configure the user access privileges in pg_hba.conf and username mapping in pg_ident.conf. One way to successfully configure the line `pg_hba.conf` from
+
+  ```
+  # TYPE  DATABASE       USER            ADDRESS                 METHOD
+  local   all             all                                     peer
+  ```
+  to
+
+  ```
+  # TYPE  DATABASE       USER            ADDRESS                 METHOD
+  local   all             all                                     trust
+  ```
 
 If you hit problems, review issues below, and ask us on Slack chat.
 


### PR DESCRIPTION
Some things I noticed when going through the installation instructions. 

In, the linux-based instructions, the ruby version was still at 2.4.2, but the `Gemfile` is locked at 2.5.0.
Also, I copied the `Postgresql` config instructions from the c9 instructions as I ran into this problem locally. 