### PR TITLE
Fix frozen event page on update request when invalid params are provided

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -38,6 +38,7 @@ class EventsController < ApplicationController
       redirect_to event_path(@event), notice: 'Event has been succesfully updated'
     else
       flash[:warning] = 'Your event was not updated successfully'
+      render :edit
     end
   end
 

--- a/features/events/edit.feature
+++ b/features/events/edit.feature
@@ -26,6 +26,12 @@ Feature: Editing an event from the event show page
     Then I should see "Event has been succesfully updated"
     And I should see "Lazier Weekend"
 
+  Scenario: As a logged in user, I should get an error when update event with invalid details
+    Given that I am logged in as any user
+    Then I visit the edit page for the event titled "Lazy Weekend"
+    When I edit with invalid details for "Lazy Weekend"
+    Then I should see "Your event was not updated successfully"
+
   Scenario: As a visitor, I cannot edit an event
     Given I am not logged in as any user
     And I visit "Open Source Weekend" event

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -66,6 +66,12 @@ Then(/^I should be on the show page for event "(.*)"/) do |event|
   expect(current_path).to eq("/events/#{event[:id]}")
 end
 
+When(/^I edit with invalid details for "(.*)"/) do |event|
+  event = Event.find_by(title: event)
+  fill_in "event_title", with: ""
+  click_button("Update Event")
+end
+
 When(/^I edit the details for "(.*)"/) do |event|
   event = Event.find_by(title: event)
   fill_in "event_title", with: "Lazier Weekend"


### PR DESCRIPTION
Addresses: https://www.pivotaltracker.com/story/show/159646331