### PR TITLE
shorten white listed method in application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,14 +15,12 @@ class ApplicationController < ActionController::Base
   # To prevent infinite redirect loops, only requests from white listed
   # controllers are available in the "after sign-in redirect" feature
   def white_listed
-    %w(
-        application
+    %w( application
         contributors
         organisations
         pages
         volunteer_ops
-        events
-    )
+        events)
   end
   # Devise wiki suggests we need to make this return nil for the
   # after_inactive_signup_path_for to be called in registrationscontroller

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,12 +15,11 @@ class ApplicationController < ActionController::Base
   # To prevent infinite redirect loops, only requests from white listed
   # controllers are available in the "after sign-in redirect" feature
   def white_listed
-    %w( application
-        contributors
-        organisations
-        pages
-        volunteer_ops
-        events)
+    %w(
+        application contributors
+        organisations pages
+        volunteer_ops events
+      )
   end
   # Devise wiki suggests we need to make this return nil for the
   # after_inactive_signup_path_for to be called in registrationscontroller

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,15 +11,18 @@ class ApplicationController < ActionController::Base
   add_breadcrumb 'home', :root_path
 
   include CustomErrors
-
+  WHITELISTED_CONTROLLERS = %w(
+   application
+   contributors
+   organisations
+   pages
+   volunteer_ops
+   events
+ )
   # To prevent infinite redirect loops, only requests from white listed
   # controllers are available in the "after sign-in redirect" feature
   def white_listed
-    %w(
-        application contributors
-        organisations pages
-        volunteer_ops events
-      )
+    WHITELISTED_CONTROLLERS
   end
   # Devise wiki suggests we need to make this return nil for the
   # after_inactive_signup_path_for to be called in registrationscontroller


### PR DESCRIPTION
Refactor white_listed method of Applicatio controller to have less than 8 lines as required by rubocop

Addresses: https://www.pivotaltracker.com/n/projects/742821/stories/157414857

[Finishes #157414857]
