### PR TITLE
[WIP] Rubocop linter warnings fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'config/**/*'
     - 'script/**/*'
     - 'bin/**/*'
+    - 'docs/installation/vagrant/*'
   TargetRubyVersion: 2.3
 
 Rails:
@@ -439,7 +440,7 @@ Style/RedundantSelf:
 Style/RegexpLiteral:
   Description: 'Use / or %r around regular expressions.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
-  Enabled: true
+  Enabled: false
 
 Layout/RescueEnsureAlignment:
   Description: 'Align rescues and ensures correctly.'
@@ -578,7 +579,7 @@ Lint/AmbiguousRegexpLiteral:
   Description: >-
                  Checks for ambiguous regexp literals in the first argument of
                  a method invocation without parenthesis.
-  Enabled: true
+  Enabled: false
 
 Lint/AssignmentInCondition:
   Description: "Don't use assignment in conditions."
@@ -731,7 +732,7 @@ Metrics/LineLength:
     - https
   Description: 'Limit lines to 90 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
-  Enabled: true
+  Enabled: false
 
 Metrics/MethodLength:
   CountComments: false  # count full line comments?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,14 +11,14 @@ class ApplicationController < ActionController::Base
   add_breadcrumb 'home', :root_path
 
   include CustomErrors
-  WHITELISTED_CONTROLLERS = %w(
+  WHITELISTED_CONTROLLERS = %w[
    application
    contributors
    organisations
    pages
    volunteer_ops
    events
- )
+ ]
   # To prevent infinite redirect loops, only requests from white listed
   # controllers are available in the "after sign-in redirect" feature
   def white_listed
@@ -66,11 +66,10 @@ class ApplicationController < ActionController::Base
 
 
   def allow_cookie_policy
-    response.set_cookie 'cookie_policy_accepted', {
+    response.set_cookie 'cookie_policy_accepted', 
         value: 'true',
         path: '/',
         expires: 1.year.from_now.utc
-    }
     #respond_to do |format|
     #  format.html redirect_to root_path
     #  format.json { render :nothing => true, :status => 200 }

--- a/app/controllers/organisation_reports_controller.rb
+++ b/app/controllers/organisation_reports_controller.rb
@@ -6,6 +6,6 @@ class OrganisationReportsController < ApplicationController
     @resend_invitation = false
     @mail_template = MailTemplate.find_by(name: 'Invitation instructions')
     @orphans = Organisation.not_null_email.null_users.without_matching_user_emails
-    render :template => 'organisation_reports/without_users_index', :layout => 'invitation_table'
+    render template: 'organisation_reports/without_users_index', layout: 'invitation_table'
   end
 end

--- a/app/controllers/proposed_organisations_controller.rb
+++ b/app/controllers/proposed_organisations_controller.rb
@@ -40,7 +40,7 @@ class ProposedOrganisationsController < BaseOrganisationsController
     @proposed_organisation = ProposedOrganisation.friendly.find(params[:id])
     proposed_organisations = ProposedOrganisation.where(id: @proposed_organisation.id)
     #refactor this into model
-    @proposer_email = @proposed_organisation.users.first.email if !@proposed_organisation.users.empty?
+    @proposer_email = @proposed_organisation.users.first.email unless @proposed_organisation.users.empty?
     @markers = build_map_markers(proposed_organisations)
   end
 

--- a/app/controllers/user_reports_controller.rb
+++ b/app/controllers/user_reports_controller.rb
@@ -20,9 +20,9 @@ class UserReportsController < ApplicationController
 
   def update
     user = User.find_by_id(params[:id])
-    if params[:pending_org_action] == "decline"
+    if params[:pending_org_action] == 'decline'
       UserOrganisationDecliner.new(self, user, current_user).call
-    elsif params[:pending_org_action] == "approve"
+    elsif params[:pending_org_action] == 'approve'
       UserOrganisationClaimer.new(self, user, current_user).call(params[:organisation_id])
     end
   end
@@ -30,7 +30,7 @@ class UserReportsController < ApplicationController
   def destroy
     user = User.find(params[:id])
     if user == current_user
-      flash[:error] = "You may not destroy your own account!"
+      flash[:error] = 'You may not destroy your own account!'
     else
       user.destroy
       flash[:success] = "You have deleted #{user.email}."
@@ -46,7 +46,7 @@ class UserReportsController < ApplicationController
     @resend_invitation = true
     @invitations = serialize_invitations
     @mail_template = MailTemplate.find_by(name: 'Invitation instructions')
-    render :template => 'user_reports/invited', :layout => 'invitation_table'
+    render template: 'user_reports/invited', layout: 'invitation_table'
   end
   
   def upgrade
@@ -71,7 +71,7 @@ class UserReportsController < ApplicationController
   end
 
   def update_failure
-    redirect_to :status => 404
+    redirect_to status: 404
   end
 
   def update_message_for_decline_success(user, pending_organisation)

--- a/app/controllers/user_reports_controller.rb
+++ b/app/controllers/user_reports_controller.rb
@@ -48,7 +48,7 @@ class UserReportsController < ApplicationController
     @mail_template = MailTemplate.find_by(name: 'Invitation instructions')
     render template: 'user_reports/invited', layout: 'invitation_table'
   end
-  
+
   def upgrade
     user = User.find(params[:id])
     if user.superadmin?
@@ -85,7 +85,8 @@ class UserReportsController < ApplicationController
 
     User.invited_not_accepted.select do |user|
       user.organisation.present? # because invitation data may be 'dirty'
-    end.map do |user|
+    end
+    .map do |user|
       {
           id: user.organisation.id,
           name: user.organisation.name,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
           :password_confirmation,
           :remember_me,
           :pending_organisation_id
-      )
+        )
     end
   end
 end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -6,7 +6,7 @@ module DeviseHelper
   # This method is intended to stay simple and it is unlikely that we are going to change
   # it to add more behavior or options.
   def devise_error_messages!
-    return "" if resource.errors.empty?
+    return '' if resource.errors.empty?
 
     errors = resource.errors
     reset_token_error = errors.to_hash.fetch(:reset_password_token,'')

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,6 +1,6 @@
 module FormHelper
   def setup_proposed_organisation_edit(proposed_organisation_edit)
-    %w{name description address postcode email website donation_info telephone}.each do |field|
+    %w[name description address postcode email website donation_info telephone].each do |field|
       proposed_organisation_edit.send("#{field}=".to_sym,proposed_organisation_edit.organisation.send(field.to_sym))
     end
     proposed_organisation_edit

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -2,9 +2,9 @@ class AdminMailer < ActionMailer::Base
 
   # The default values for any email we send from AdminMailer.
   # Any value can be overridden on a per-email basis.
-  default from: "support@harrowcn.org.uk",
-          cc: "technical@harrowcn.org.uk",
-          reply_to: "support@harrowcn.org.uk"
+  default from: 'support@harrowcn.org.uk',
+          cc: 'technical@harrowcn.org.uk',
+          reply_to: 'support@harrowcn.org.uk'
 
   def new_user_waiting_for_approval(org_name, superadmin_emails)
     @org_name = org_name
@@ -14,13 +14,13 @@ class AdminMailer < ActionMailer::Base
 
   def new_user_sign_up(user_email, superadmin_emails)
     @user_email = user_email
-    mail(subject: "A new user has joined Harrow Community Network",
+    mail(subject: 'A new user has joined Harrow Community Network',
          to: superadmin_emails)
   end
 
   def new_org_waiting_for_approval(org, superadmin_emails)
     @org = org
-    mail(subject: "A new organisation has been proposed for inclusion in Harrow Community Network",
+    mail(subject: 'A new organisation has been proposed for inclusion in Harrow Community Network',
          to: superadmin_emails)
   end
 

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -6,9 +6,9 @@ class CustomDeviseMailer < Devise::Mailer
 
   # The default values for any email we send from CustomDeviseMailer.
   # Any value can be overridden on a per-email basis.
-  default from: "support@harrowcn.org.uk",
-          cc: "technical@harrowcn.org.uk",
-          reply_to: "support@harrowcn.org.uk"
+  default from: 'support@harrowcn.org.uk',
+          cc: 'technical@harrowcn.org.uk',
+          reply_to: 'support@harrowcn.org.uk'
 
   # from devise_invitable-1.2.1/lib/devise_invitable/mailer.rb
   def invitation_instructions(record, token, opts={})
@@ -21,7 +21,7 @@ class CustomDeviseMailer < Devise::Mailer
   def proposed_org_approved(org,email, usr)
     @org = org
     @resource = usr
-    mail(subject: "Your organisation has been approved for inclusion in the Harrow Community Network!",
+    mail(subject: 'Your organisation has been approved for inclusion in the Harrow Community Network!',
          to: [email])
   end
 

--- a/app/mailers/org_admin_mailer.rb
+++ b/app/mailers/org_admin_mailer.rb
@@ -2,19 +2,19 @@ class OrgAdminMailer < ActionMailer::Base
 
   # The default values for any email we send from OrgAdminMailer.
   # Any value can be overridden on a per-email basis.
-  default from: "support@harrowcn.org.uk",
-          cc: "technical@harrowcn.org.uk",
-          reply_to: "support@harrowcn.org.uk"
+  default from: 'support@harrowcn.org.uk',
+          cc: 'technical@harrowcn.org.uk',
+          reply_to: 'support@harrowcn.org.uk'
 
   def new_org_admin(org, emails)
     @org = org
-    mail(subject: "You have been made an organisation administrator on the Harrow Community Network",
+    mail(subject: 'You have been made an organisation administrator on the Harrow Community Network',
          to: emails)
   end
 
   def notify_proposed_org_accepted(org, email)
     @org = org
-    mail(subject:"Your Organisation has been accepted for inclusion on the Harrow Community Network",
+    mail(subject:'Your Organisation has been accepted for inclusion on the Harrow Community Network',
          to: [email])
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,7 +2,7 @@ require 'csv'
 
 class Category < ApplicationRecord
   has_many :category_organisations
-  has_and_belongs_to_many :base_organisations, :through => :category_organisations, :association_foreign_key => :organisation_id
+  has_and_belongs_to_many :base_organisations, through: :category_organisations, association_foreign_key: :organisation_id
 
   scope :what_they_do,  -> { subcategory(100, 199) }
   scope :who_they_help, -> { subcategory(200, 299) }
@@ -28,10 +28,10 @@ class Category < ApplicationRecord
   end
   def self.seed(csv_file)
     csv_text = File.open(csv_file, 'r:ISO-8859-1')
-    CSV.parse(csv_text, :headers => true).each do |row|
-      Category.create! :name => row[@@column_mappings[:name]].strip,
-                       :charity_commission_id => row[@@column_mappings[:cc_id]],
-                       :charity_commission_name => row[@@column_mappings[:cc_name]].strip
+    CSV.parse(csv_text, headers: true).each do |row|
+      Category.create! name: row[@@column_mappings[:name]].strip,
+                       charity_commission_id: row[@@column_mappings[:cc_id]],
+                       charity_commission_name: row[@@column_mappings[:cc_name]].strip
     end
   end
 
@@ -43,7 +43,7 @@ class Category < ApplicationRecord
     end
     def <=> other
       if (@sym == :what_they_do && other.sym == :how_they_help) || (@sym == :what_they_do && other.sym == :who_they_help) ||
-        (@sym == :who_they_help && other.sym == :how_they_help)
+         (@sym == :who_they_help && other.sym == :how_they_help)
         -1
       elsif @sym == other.sym
         0

--- a/app/models/category_organisation.rb
+++ b/app/models/category_organisation.rb
@@ -1,5 +1,5 @@
 class CategoryOrganisation < ApplicationRecord
   belongs_to :category
-  belongs_to :base_organisation, :foreign_key => :organisation_id
+  belongs_to :base_organisation, foreign_key: :organisation_id
   self.table_name = 'categories_organisations'
 end

--- a/app/models/csv_header.rb
+++ b/app/models/csv_header.rb
@@ -1,7 +1,7 @@
 class CSVHeader
 
   def self.build
-    new({
+    new(
       name: 'Title',
       address: 'Contact Address',
       description: 'Activities',
@@ -9,7 +9,7 @@ class CSVHeader
       telephone: 'Contact Telephone',
       date_removed: 'date removed',
       cc_id: 'Charity Classification'
-    })
+    )
   end
 
   def initialize(header_names)

--- a/app/models/first_capitals_humanizer.rb
+++ b/app/models/first_capitals_humanizer.rb
@@ -1,5 +1,5 @@
 class FirstCapitalsHumanizer
   def self.call(phrase)
-    phrase.humanize.split(' ').map{|w| w.capitalize}.join(' ')
+    phrase.humanize.split(' ').map(&:capitalize).join(' ')
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -11,14 +11,14 @@ class Organisation < BaseOrganisation
   accepts_nested_attributes_for :users # TODO check if needed
 
   scope :order_by_most_recent, -> { order('organisations.updated_at DESC') }
-  scope :not_null_email, lambda {where("organisations.email <> ''")}
+  scope :not_null_email, -> {where("organisations.email <> ''")}
 
   # Should we not use :includes, which pulls in extra data? http://nlingutla.com/blog/2013/04/21/includes-vs-joins-in-rails/
   # Alternative => :joins('LEFT OUTER JOIN users ON users.organisation_id = organisations.id)
   # Difference between inner and outer joins: http://stackoverflow.com/a/38578/2197402
 
-  scope :null_users, lambda { includes(:users).where("users.organisation_id IS NULL").references(:users) }
-  scope :without_matching_user_emails, lambda {where("organisations.email NOT IN (#{User.select('email').to_sql})")}
+  scope :null_users, -> { includes(:users).where('users.organisation_id IS NULL').references(:users) }
+  scope :without_matching_user_emails, -> {where("organisations.email NOT IN (#{User.select('email').to_sql})")}
 
   after_save :uninvite_users, if: ->{ saved_change_to_attribute?(:email) }
 
@@ -83,7 +83,7 @@ class Organisation < BaseOrganisation
   end
 
   def self.import_category_mappings(filename, limit)
-    import(filename, limit, false) do |row, validation|
+    import(filename, limit, false) do |row, _validation|
       import_categories_from_array(row)
     end
   end
@@ -108,10 +108,10 @@ class Organisation < BaseOrganisation
     end
   end
 
-  def self.import(filename, limit, validation, &block)
+  def self.import(filename, limit, validation)
     csv_text = File.open(filename, 'r:ISO-8859-1')
     count = 0
-    CSV.parse(csv_text, :headers => true).each do |row|
+    CSV.parse(csv_text, headers: true).each do |row|
       break if count >= limit
       count += 1
       begin
@@ -130,7 +130,7 @@ class Organisation < BaseOrganisation
     str
   end
 
-  def self.add_email(row, validation)
+  def self.add_email(row, _validation)
     orgs = where('UPPER(name) LIKE ? ',"%#{row[0].try(:upcase)}%")
     return "#{row[0]} was not found\n" unless orgs && orgs[0] && orgs[0].email.blank?
     setup_row(orgs[0], row)
@@ -154,7 +154,7 @@ class Organisation < BaseOrganisation
   private
 
   def embellish_invite_error_and_add_to_model(email, error_msg)
-    error_msg = ("Error: Email is invalid" == error_msg) ? "The user email you entered,'#{email}', is invalid" : error_msg
+    error_msg = ('Error: Email is invalid' == error_msg) ? "The user email you entered,'#{email}', is invalid" : error_msg
     self.errors.add(:superadministrator_email, error_msg)
   end
 

--- a/app/models/proposed_organisation.rb
+++ b/app/models/proposed_organisation.rb
@@ -1,5 +1,5 @@
 class ProposedOrganisation < BaseOrganisation
-  has_many :users, :foreign_key => 'organisation_id'
+  has_many :users, foreign_key: 'organisation_id'
   
   def accept_proposal
     org = becomes!(Organisation)

--- a/app/models/proposed_organisation_edit.rb
+++ b/app/models/proposed_organisation_edit.rb
@@ -2,7 +2,7 @@ require 'proposes_edits'
 class ProposedOrganisationEdit < ApplicationRecord
   acts_as_paranoid
   belongs_to :organisation
-  belongs_to :editor, :class_name => 'User', :foreign_key => 'user_id'
+  belongs_to :editor, class_name: 'User', foreign_key: 'user_id'
   include ProposesEdits
   proposes_edits_to :organisation
   editable_fields :address, :name, :description, :postcode, :email, :website, :telephone, :donation_info

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ApplicationRecord
     superadmin? || (!org.nil? && organisation == org)
   end
 
-  def can_delete? org
+  def can_delete? _org
     superadmin?
   end
 

--- a/app/models/volunteer_op.rb
+++ b/app/models/volunteer_op.rb
@@ -71,9 +71,7 @@ class VolunteerOp < ApplicationRecord
 
   def self.get_source(volunteer_ops)
     source = volunteer_ops.first.source
-    unless volunteer_ops.all? { |vol_op| vol_op.source == source }
-      source = 'mixed'
-    end
+    source = 'mixed' unless volunteer_ops.all? { |vol_op| vol_op.source == source }
     source
   end
 

--- a/app/services/accept_proposed_organisation.rb
+++ b/app/services/accept_proposed_organisation.rb
@@ -1,10 +1,10 @@
 class AcceptProposedOrganisation
   class Response
-    NOTIFICATION_SENT = "Notification sent"
-    INVITATION_SENT = "Invitation sent"
-    INVALID_EMAIL = "Invalid Email"
-    NO_EMAIL = "No email"
-    OTHER_ERROR = "Other Error"
+    NOTIFICATION_SENT = 'Notification sent'
+    INVITATION_SENT = 'Invitation sent'
+    INVALID_EMAIL = 'Invalid Email'
+    NO_EMAIL = 'No email'
+    OTHER_ERROR = 'Other Error'
 
     attr_reader   :status, :error_msg 
     attr_accessor :accepted_org, :not_accepted_org

--- a/app/services/batch_invite_job.rb
+++ b/app/services/batch_invite_job.rb
@@ -1,6 +1,6 @@
 class BatchInviteJob
 
-  def initialize(params, current_user)
+  def initialize(params, _current_user)
     @resend_invitation = params.fetch(:resend_invitation)
     @invites = params.fetch(:invite_list)
     @mail_template = MailTemplate.find_by(name: 'Invitation instructions')

--- a/app/services/import_do_it_volunteer_opportunities.rb
+++ b/app/services/import_do_it_volunteer_opportunities.rb
@@ -19,7 +19,7 @@ class ImportDoItVolunteerOpportunities
   end
 
   HOST = 'https://api.do-it.org'
-  HREF = "/v1/opportunities?lat=51.5978&lng=-0.3370&miles="
+  HREF = '/v1/opportunities?lat=51.5978&lng=-0.3370&miles='
 
   def run
     href = "#{HREF}#{radius}"
@@ -27,7 +27,6 @@ class ImportDoItVolunteerOpportunities
     while href = process_doit_json_page(http.get("#{HOST}#{href}"));
     end
   end
-
   def process_doit_json_page from_response
     return nil unless content? from_response
     persist_doit opportunities(from_response)
@@ -63,7 +62,7 @@ class ImportDoItVolunteerOpportunities
     !op['locations'][0]['local_authority']['name'].downcase.include? 'harrow'
   end
 
-  def populate_vol_op_attributes model, op
+  def populate_vol_op_attributes model, op # rubocup:disable Metrics/MethodLenght
     location = Location.new longitude: op['lng'], latitude: op['lat']
     model.source        = 'doit'
     model.latitude      = location.latitude

--- a/app/services/invite_unregistered_user_from_proposed_org.rb
+++ b/app/services/invite_unregistered_user_from_proposed_org.rb
@@ -1,10 +1,10 @@
 class InviteUnregisteredUserFromProposedOrg
 
   class Response
-    INVALID_EMAIL = "Invalid Email"
-    NO_EMAIL = "No Email"
-    OTHER_FAILURE = "Other Failure"
-    SUCCESS = "Success"
+    INVALID_EMAIL = 'Invalid Email'
+    NO_EMAIL = 'No Email'
+    OTHER_FAILURE = 'Other Failure'
+    SUCCESS = 'Success'
 
     attr_reader :status, :error_msg
 
@@ -30,7 +30,7 @@ class InviteUnregisteredUserFromProposedOrg
     # accept the invite. You can set it like so:
     # user.deliver_invitation
     #but this seems not to be necessary right now per acceptance tests
-    usr = User.invite!(:email => @email) do |u|
+    usr = User.invite!(email: @email) do |u|
       u.skip_invitation = true
       u.skip_confirmation!
       u.organisation = @org
@@ -46,13 +46,13 @@ class InviteUnregisteredUserFromProposedOrg
   def create_response_object(usr)
     return Response.new(Response::SUCCESS, nil) if usr.errors.empty?
     status =  case usr.errors.full_messages.first
-      when "Email can't be blank"
+              when "Email can't be blank"
         Response::NO_EMAIL
-      when "Email is invalid"
+              when 'Email is invalid'
         Response::INVALID_EMAIL
       else
         Response::OTHER_FAILURE
     end
-    return Response.new(status,usr.errors.full_messages.first)
+    Response.new(status,usr.errors.full_messages.first)
   end
 end

--- a/app/services/queries/organisations.rb
+++ b/app/services/queries/organisations.rb
@@ -25,7 +25,7 @@ module Queries
     def self.add_recently_updated_and_has_owner(organisations)
       one_year_ago = Time.current.advance(years: -1)
       recently_updated = "organisations.updated_at > '#{one_year_ago.strftime(FORMAT)}'"
-      has_owner = "organisations.id IN (SELECT users.organisation_id FROM users)"
+      has_owner = 'organisations.id IN (SELECT users.organisation_id FROM users)'
       condition =
         "CASE WHEN #{recently_updated} AND #{has_owner} THEN TRUE ELSE FALSE END"
       organisations

--- a/app/services/single_invite_job.rb
+++ b/app/services/single_invite_job.rb
@@ -7,14 +7,14 @@ class SingleInviteJob
   end
 
   def initialize(org, email)
-    @batch_invite = ::BatchInviteJob.new({:resend_invitation => false, :invite_list => {org.id.to_s => email}}, nil)
+    @batch_invite = ::BatchInviteJob.new({resend_invitation: false, invite_list: {org.id.to_s => email}}, nil)
     @org_id = org.id
     @email = email
   end
 
   def invite_user
     result = batch_invite.run
-    return SingleInviteResult.new(result[org_id.to_s]) if result[org_id.to_s] != "Invited!"
+    return SingleInviteResult.new(result[org_id.to_s]) if result[org_id.to_s] != 'Invited!'
     SingleInviteResult.new
   end
 

--- a/app/services/user_organisation_claimer.rb
+++ b/app/services/user_organisation_claimer.rb
@@ -27,9 +27,7 @@ class UserOrganisationClaimer
   end
 
   def error_message_if_not_superadmin_or_not(organisation_id)
-    if !is_current_user_superadmin? && !organisation_id
-      listener.update_failure
-    end
+    listener.update_failure if !is_current_user_superadmin? && !organisation_id
   end
 
   def promote_user_if_superadmin_and_not(organisation_id)

--- a/autotest/discover.rb
+++ b/autotest/discover.rb
@@ -1,2 +1,2 @@
-Autotest.add_discovery { "rails" }
-Autotest.add_discovery { "rspec2" }
+Autotest.add_discovery { 'rails' }
+Autotest.add_discovery { 'rspec2' }

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -6,61 +6,61 @@ Given /^I am signed in as a charity worker (un)?related to "(.*?)"$/ do |negate,
   else
     user = organisation.users.find { |user| !user.superadmin? }
   end
-  page.set_rack_session("warden.user.user.key" => User.serialize_into_session(user))
+  page.set_rack_session('warden.user.user.key' => User.serialize_into_session(user))
 end
 
 Given /^I am signed in as a (non-)?siteadmin$/ do |negate|
   user = User.find_by(siteadmin: negate ? false : true)
-  page.set_rack_session("warden.user.user.key" => User.serialize_into_session(user))
+  page.set_rack_session('warden.user.user.key' => User.serialize_into_session(user))
 end
 
 Given /^I am signed in as an? (non-)?superadmin$/ do |negate|
   user = User.find_by_superadmin(negate ? false : true)
-  page.set_rack_session("warden.user.user.key" => User.serialize_into_session(user))
+  page.set_rack_session('warden.user.user.key' => User.serialize_into_session(user))
 end
 
 Given /^I am signed in as a pending admin of "(.*?)"$/ do |org_name|
   org = Organisation.find_by_name org_name
   user = User.find_by_pending_organisation_id(org.id)
-  page.set_rack_session("warden.user.user.key" => User.serialize_into_session(user))
+  page.set_rack_session('warden.user.user.key' => User.serialize_into_session(user))
 end
 
 Given /^I sign up as "(.*?)" with password "(.*?)" and password confirmation "(.*?)"( on the legacy sign up page)?$/ do |email, password, password_confirmation, legacy|
   if legacy
     within('#new_user') do
-      fill_in "user_email", :with => email
-      fill_in "user_password", :with => password
-      fill_in "user_password_confirmation", :with => password_confirmation
-      click_button "Sign up"
+      fill_in 'user_email', with: email
+      fill_in 'user_password', with: password
+      fill_in 'user_password_confirmation', with: password_confirmation
+      click_button 'Sign up'
     end
   else
     within('.dropdown-menu') do
-      fill_in "signup_email", :with => email
-      fill_in "signup_password", :with => password
-      fill_in "signup_password_confirmation", :with => password_confirmation
-      click_button "Sign up"
+      fill_in 'signup_email', with: email
+      fill_in 'signup_password', with: password
+      fill_in 'signup_password_confirmation', with: password_confirmation
+      click_button 'Sign up'
     end
     using_wait_time(15) { expect(page).not_to have_css('#signup') } if @javascript
   end
 end
 
 Given /^that I am logged in as any user$/ do
-  steps %Q{
+  steps %(
      Given the following users are registered:
    | email             | password | confirmed_at         |
    | registered_user@example.com | pppppppp | 2007-01-01  10:00:00 |
-  }
-  steps %Q{
+  )
+  steps %(
     Given I visit the home page
     And I sign in as "registered_user@example.com" with password "pppppppp"
-  }
+  )
 end
 
 Then /^I should not be signed in as any user$/ do
-  steps %Q{
+  steps %(
     Given I visit the new organisation page
     Then I should not see "Signed in as"
-  }
+  )
 end
 
 When /^I sign out$/ do
@@ -68,31 +68,31 @@ When /^I sign out$/ do
 end
 
 Given /^I sign in as "(.*?)" with password "(.*?)"( with javascript)?$/ do |email, password, js|
-  fill_in "user_email", :with => email
-  fill_in "user_password", :with => password
+  fill_in 'user_email', with: email
+  fill_in 'user_password', with: password
   if js
-    page.find("#signin").trigger("click")
+    page.find('#signin').trigger('click')
     expect(page).not_to have_css('#signin')
   else
-    click_link_or_button "Sign in"
+    click_link_or_button 'Sign in'
   end
 end
 
 Given /^I sign in as "(.*?)" with password "(.*?)" on the legacy sign in page$/ do |email, password|
-  within("#new_user") do
-    fill_in "user_email", :with => email
-    fill_in "user_password", :with => password
-    click_link_or_button "Sign in"
+  within('#new_user') do
+    fill_in 'user_email', with: email
+    fill_in 'user_password', with: password
+    click_link_or_button 'Sign in'
   end
 end
 
 When(/^I sign in as "(.*?)" with password "(.*?)" via email confirmation$/) do |email, password|
   user = User.find_by_email("#{email}")
   user.confirm
-  steps %Q{
+  steps %(
     Given I visit the home page
     And I sign in as "#{email}" with password "#{password}"
-  }
+  )
 end
 
 And(/^cookies are approved$/) do
@@ -105,7 +105,7 @@ end
 
 def extract_confirmation_link email
   emails_with_confirmation_link = find_emails_with_confirmation_link(find_emails_to(email))
-  Nokogiri::HTML(emails_with_confirmation_link.first.body.raw_source).search("//a[text()='Confirm my account']")[0].attribute("href").value
+  Nokogiri::HTML(emails_with_confirmation_link.first.body.raw_source).search("//a[text()='Confirm my account']")[0].attribute('href').value
 end
 
 def find_emails_with_confirmation_link emails
@@ -119,7 +119,7 @@ end
 
 def extract_retrieve_password_link email
   emails_with_retrieve_password_link = find_emails_with_retrieve_password_link(find_emails_to(email))
-  Nokogiri::HTML(emails_with_retrieve_password_link.first.body.raw_source).search("//a[text()='Change my password']")[0].attribute("href").value
+  Nokogiri::HTML(emails_with_retrieve_password_link.first.body.raw_source).search("//a[text()='Change my password']")[0].attribute('href').value
 end
 
 def find_emails_with_retrieve_password_link emails
@@ -131,13 +131,13 @@ Given(/^I click on the retrieve password link in the email to "([^\"]+)"$/) do |
 end
 
 Given(/^I receive a new password for "(.*?)"$/) do |email|
-  steps %Q{
+  steps %(
     Given I visit the home page
     And I follow "Forgot your password?"
     And I fill in "user_retrieval_email" with "#{email}" within the main body
     And I press "Send me reset password instructions"
     And I click on the retrieve password link in the email to "#{email}"
-  }
+  )
 end
 
 def find_emails_to email
@@ -150,12 +150,12 @@ end
 
 def extract_invite_link email
   emails_with_accept_link = find_emails_with_accept_invitation_link(find_emails_to(email), 'Accept invitation')
-  Nokogiri::HTML(emails_with_accept_link.first.body.raw_source).search("//a[text()='Accept invitation']")[0].attribute("href").value
+  Nokogiri::HTML(emails_with_accept_link.first.body.raw_source).search("//a[text()='Accept invitation']")[0].attribute('href').value
 end
 
 def extract_invite_link_for_proposed_org email
-  emails_with_accept_link = find_emails_with_accept_invitation_link(find_emails_to(email), "You can get admin access and edit your organisation details by clicking here.")
-  Nokogiri::HTML(emails_with_accept_link.first.body.raw_source).search("//a[text()='You can get admin access and edit your organisation details by clicking here.']")[0].attribute("href").value
+  emails_with_accept_link = find_emails_with_accept_invitation_link(find_emails_to(email), 'You can get admin access and edit your organisation details by clicking here.')
+  Nokogiri::HTML(emails_with_accept_link.first.body.raw_source).search("//a[text()='You can get admin access and edit your organisation details by clicking here.']")[0].attribute('href').value
 end
 
 def find_emails_with_view_link_for_accepted_org emails, verbiage
@@ -163,27 +163,27 @@ def find_emails_with_view_link_for_accepted_org emails, verbiage
 end
 
 def extract_view_link_for_accepted_org email
-  emails_with_view_link = find_emails_with_view_link_for_accepted_org(find_emails_to(email),"You can edit your organisation details by logging in and editing it directly.")
-  Nokogiri::HTML(emails_with_view_link.first.body.raw_source).search("//a[text()='You can edit your organisation details by logging in and editing it directly.']")[0].attribute("href").value
+  emails_with_view_link = find_emails_with_view_link_for_accepted_org(find_emails_to(email),'You can edit your organisation details by logging in and editing it directly.')
+  Nokogiri::HTML(emails_with_view_link.first.body.raw_source).search("//a[text()='You can edit your organisation details by logging in and editing it directly.']")[0].attribute('href').value
 end
 
 And(/^I click on the invitation link in the proposed org accepted email to "(.*?)"$/) do |email|
   visit extract_invite_link_for_proposed_org(email)
-  step "I should be on the invitation page"
+  step 'I should be on the invitation page'
 end
 
 Given(/^I click on the invitation link in the email to "([^\"]+)"$/) do |email|
   visit extract_invite_link(email)
-  step "I should be on the invitation page"
+  step 'I should be on the invitation page'
 end
 
 And(/^I accepted the cookie policy from the "([^\"]+)" page$/) do |page|
-  step %Q{I click "Close"}
+  step %(I click "Close")
   step "I should be on the #{page} page"
 end
 
 And(/^I set my password/) do
-  step %Q{I fill in "user_password" with "12345678" within the main body}
-  step %Q{I fill in "user_password_confirmation" with "12345678" within the main body}
-  step %Q{I press "Set my password"}
+  step %(I fill in "user_password" with "12345678" within the main body)
+  step %(I fill in "user_password_confirmation" with "12345678" within the main body)
+  step %(I press "Set my password")
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -14,7 +14,7 @@ Then(/^I should see the "(.*?)" image linked to "(.*?)"$/) do |image_alt, link|
 end
 
 Then(/^I should see the "(.*?)" image linked to contributors$/) do |image_alt|
-  steps %{Then I should see the "#{image_alt}" image linked to "#{contributors_path}"}
+  steps %(Then I should see the "#{image_alt}" image linked to "#{contributors_path}")
 end
 
 Then /^I should see permission denied$/ do
@@ -41,14 +41,14 @@ Then /^I should see the cannot add non registered user "(.*?)" as charity supera
 end
 
 And /^I add "(.*?)" as a superadmin for "(.*?)" charity$/ do |superadmin_email, charity|
-  steps %Q{ And I visit the edit page for the organisation named "#{charity}"}
+  steps %( And I visit the edit page for the organisation named "#{charity}")
   fill_in 'organisation_superadmin_email_to_add', with: superadmin_email
-  steps %Q{
-  And I press "Update Organisation"}
+  steps %(
+  And I press "Update Organisation")
 end
 
 Then /^I should see the no charity superadmins message$/ do
-  expect(page).to have_content "This organisation has no admins yet"
+  expect(page).to have_content 'This organisation has no admins yet'
 end
 
 Given /^I delete "(.*?)" charity$/ do |name|
@@ -76,7 +76,7 @@ Then /^I should( not)? see "(.*?)" in the charity superadmin email$/ do |negate,
 end
 
 Then /^show me the page$/ do
-  save_and_open_page
+  save_and_open_page # rubocop:disable Lint/Debugger
 end
 
 When /^I search for "(.*?)"$/ do |text|
@@ -103,15 +103,15 @@ Given (/^I fill in the new charity page validly including the categories:$/) do 
   fill_in 'organisation_name', with: 'Friendly charity'
   fill_in 'organisation_postcode', with: 'HA1 4HZ'
   categories_table.hashes.each do |cat|
-    steps %Q{
+    steps %(
       And I check the category "#{cat[:name]}"
-    }
+    )
   end
 end
 
 Given(/^I am proposing an organisation$/) do
   visit new_proposed_organisation_path
-  steps %Q{And I fill in the proposed charity page validly}
+  steps %(And I fill in the proposed charity page validly)
 end
 
 Given (/^I fill in the proposed charity page validly$/) do
@@ -119,9 +119,9 @@ Given (/^I fill in the proposed charity page validly$/) do
     fill_in "proposed_organisation_#{key}", with: val
   end
   proposed_org_categories.each do |cat|
-    steps %Q{
+    steps %(
       And I check the category "#{cat}"
-    }
+    )
   end
 end
 
@@ -157,61 +157,61 @@ Then(/^I should see all the proposed organisation fields$/) do
 end
 
 Then /^the contact information should be available$/ do
-  steps %Q{
+  steps %{
     When I follow "Contact"
     Then I should see "Contact Info Email us: contact@voluntaryactionharrow.org.uk Phone Us: 020 8861 5894 Write to Us: The Lodge, 64 Pinner Road, Harrow, Middlesex, HA1 4HZ Find Us: On Social Media (Click Here)"
    }
 end
 
 Then /^the about us should be available$/ do
-  steps %Q{
+  steps %{
     When I follow "About Us"
     Then I should see "About Us Supporting groups in Harrow We are a not-for-profit workers co-operative who support people and not-for-profit organisations to make a difference in their local community by: Working with local people and groups to identify local needs and develop appropriate action. Providing a range of services that help organisations to succeed. Supporting and encouraging the growth of co-operative movement. How do we support? Find out here (VAH in a nutshell) What is a Workers Co-operative? A workers co-operative is a business owned and democratically controlled by their employee members using co-operative principles. They are an attractive and increasingly relevant alternative to traditional investor owned models of enterprise. (Click here for more details)"
   }
 end
 
 Given /^I update "(.*?)" charity address to be "(.*?)"( when Google is indisposed)?$/ do |name, address, indisposed|
-  steps %Q{
+  steps %(
     Given I visit the show page for the organisation named "#{name}"
     And I follow "Edit"
     And I edit the charity address to be "#{address}" #{indisposed ? 'when Google is indisposed' : ''}
     And I press "Update Organisation"
-  }
+  )
 end
 
 Given(/^I edit the charity email of "(.*?)" to be "(.*?)"$/) do |name, email|
-  steps %Q{
+  steps %(
     Given I visit the show page for the organisation named "#{name}"
     And I follow "Edit"
     And I edit the charity email to be "#{email}"
     And I press "Update Organisation"
-  }
+  )
 end
 
 Given /^I update "(.*?)" charity website to be "(.*?)"$/ do |name, url|
-  steps %Q{
+  steps %(
     Given I visit the show page for the organisation named "#{name}"
     And I follow "Edit"
     And I edit the charity website to be "#{url}"
     And I press "Update Organisation"
-  }
+  )
 end
 
 Given /^I have created a new organisation$/ do
-  steps %Q{
+  steps %(
     Given I visit the home page
     And I follow "New Organisation"
     And I fill in the new charity page validly
     And I press "Create Organisation"
-   }
+   )
 end
 
 Given /^I furtively update "(.*?)" charity address to be "(.*?)"$/ do |name, address|
-  steps %Q{
+  steps %(
     Given I am furtively on the edit charity page for "#{name}"
     And I edit the charity address to be "#{address}"
     And I press "Update Organisation"
-  }
+  )
 end
 
 Given /^I edit the charity website to be "(.*?)"$/ do |url|
@@ -227,9 +227,9 @@ When /^I edit the charity address to be "(.*?)"$/ do |address|
 end
 
 Then /^the website link for "(.*?)" should have a protocol$/ do |name|
-  steps %{
+  steps %(
     Given I visit the show page for the organisation named "#{name}"
-  }
+  )
   website = Organisation.find_by_name(name).website
   website.should =~ /^http\:\/\//
   expect(page).to have_selector("a[href='#{website}']")
@@ -248,7 +248,7 @@ end
 Then /^I should see the donation_info URL for "(.*?)"$/ do |name1|
   org1 = Organisation.find_by_name(name1)
   content = "Donate to #{org1.name} now!"
-  page.should have_xpath %Q<//a[@href = "#{org1.donation_info}" and @target = "_blank" and contains(.,'#{content}')]>
+  page.should have_xpath %<//a[@href = "#{org1.donation_info}" and @target = "_blank" and contains(.,'#{content}')]>
 end
 
 Then /^the donation_info URL for "(.*?)" should refer to "(.*?)"$/ do |name, href|
@@ -284,7 +284,7 @@ end
 
 Given /^I update the "(.*?)"$/ do |name|
   org1 = Organisation.find_by_name(name)
-  org1.address = "84 pinner road"
+  org1.address = '84 pinner road'
   org1.save!
 end
 
@@ -299,17 +299,17 @@ Given /^I edit the donation url to be "(.*?)"$/ do |url|
 end
 
 Then /^I should not see any edit or delete links$/ do
-  page.should_not have_link "Edit"
-  page.should_not have_link "Destroy"
+  page.should_not have_link 'Edit'
+  page.should_not have_link 'Destroy'
 end
 
-Then /^I should not see any edit link for "([^"]*?)"$/ do |name1|
-  page.should_not have_link "Edit"
+Then /^I should not see any edit link for "([^"]*?)"$/ do |_name1|
+  page.should_not have_link 'Edit'
 end
 
 Then /^I should see the external website link for "(.*?)" charity$/ do |org_name|
   org = Organisation.find_by_name org_name
-  page.should have_xpath %Q<//a[@target = "_blank" and @href = "#{org.website}" and contains(.,'#{org.website}')]>
+  page.should have_xpath %<//a[@target = "_blank" and @href = "#{org.website}" and contains(.,'#{org.website}')]>
 end
 
 Then /^I should( not)? see a link with text "([^"]*?)"$/ do |negate, link|
@@ -343,7 +343,7 @@ Then /^I should( not)? see "([^"]*)"$/ do |negate, text|
   expect(page).send(expectation_method, have_content(text))
 end
 
-Then(/^I should( not)? see "([^"]*)" in "([^"]*)"/) do |negate, text, selector|
+Then(/^I should( not)? see "([^"]*)" in "([^"]*)"/) do |negate, _text, selector|
   expectation_method = negate ? :not_to : :to
   within("#{selector}") do
     expect(page.body).send(expectation_method, match(/text/))
@@ -388,13 +388,13 @@ Then(/^I should not see "(.*?)"  within "(.*?)"$/) do |text, selector|
 end
 
 Given /^I update "(.*?)" charity postcode to be "(.*?)"$/ do |name, postcode|
-  steps %Q{And I visit the edit page for the organisation named "#{name}"}
+  steps %(And I visit the edit page for the organisation named "#{name}")
   fill_in('organisation_postcode', with: postcode)
   click_button 'Update Organisation'
 end
 
 Given /^I edit the charity address to be "(.*?)" when Google is indisposed$/ do |address|
-  body = %Q({
+  body = %({
 "results" : [],
 "status" : "OVER_QUERY_LIMIT"
 })
@@ -402,7 +402,7 @@ Given /^I edit the charity address to be "(.*?)" when Google is indisposed$/ do 
 end
 
 Then /^I should not see the unable to save organisation error$/ do
-  page.should_not have_content "1 error prohibited this organisation from being saved:"
+  page.should_not have_content '1 error prohibited this organisation from being saved:'
 end
 
 Then /^the address for "(.*?)" should be "(.*?)"$/ do |name, address|
@@ -434,19 +434,19 @@ Then(/^"(.*?)" should have email "(.*?)"$/) do |org, email|
 end
 
 And /^I click "(.*)" on the "(.*)" page and stay there$/  do |link, org_name|
-  steps %Q{
+  steps %(
     And I visit the show page for the organisation named "#{org_name}"
     And I click "#{link}"
     Then I should be on the show page for the organisation named "#{org_name}"
-  }
+  )
 end
 
 Given /^"(.*)"'s request status for "(.*)" should be updated appropriately$/ do |email, org_name|
-  steps %Q{
+  steps %(
       And "#{email}"'s request for "#{org_name}" should be persisted
       And I should see "You have requested superadmin status for #{Organisation.find_by_name(org_name).name}"
       And I should not see a link or button "This is my organisation"
-    }
+    )
 end
 
 And /"(.*)"'s request for "(.*)" (should|should not) be persisted/ do |email, org, expectation|
@@ -575,7 +575,7 @@ Given /^associations are destroyed for:$/ do |table|
 end
 
 Given /^I debug/ do
-  byebug
+  byebug # rubocop:disable Lint/Debugger
 end
 
 Given /^I run the invite migration$/ do
@@ -594,21 +594,21 @@ Then(/^I should have a page with a title tag set to: "([^"]*)"$/) do |title|
 end
 
 And(/^it should have ?a? Meta (.*)$/) do |name_attribute|
-  expect(page.find(%Q{meta[name="#{name_attribute.downcase}"]}, :visible => false).class).to eq(Capybara::Node::Element)
+  expect(page.find(%(meta[name="#{name_attribute.downcase}"]), visible: false).class).to eq(Capybara::Node::Element)
 end
 
 Then(/^I should see a link to feedback form in the footer$/) do
   feedback_url = 'https://docs.google.com/a/neurogrid.com/forms/d/1iQwIM0E2gjJF6N6UHgVwtH8OzBbpUr6DS0Xbf-UrKE0/viewform'
   page.should have_link('feedback here',
-    :href => feedback_url
+    href: feedback_url
   )
 end
 
-When("I fill in {string} with {string}") do |field, text|
+When('I fill in {string} with {string}') do |field, text|
   fill_in field, with: text
 end
 
-Then("I should see a text field for {string}") do |name|
+Then('I should see a text field for {string}') do |name|
   find_field(name)
 end
 

--- a/features/step_definitions/category_steps.rb
+++ b/features/step_definitions/category_steps.rb
@@ -21,27 +21,27 @@ end
 
 Then(/^the "(.*?)" category should be selected from (What They Do|How They Help|Who They Help)$/) do |name, cat_type|
   cat_id = case cat_type
-    when 'What They Do'
+           when 'What They Do'
       '#what_id'
-    when 'How They Help'
+           when 'How They Help'
       '#how_id'
-    when 'Who They Help'
+           when 'Who They Help'
       '#who_id'
     else
-      raise "Unsupported category type"
+      raise 'Unsupported category type'
   end
   id = Category.find_by(name: name).id.to_s
   find(cat_id).value.should eq id
 end
 
 Then(/^the default all value should be selected from What They Do$/) do
-  expect(find("#what_id").value).to be_empty
+  expect(find('#what_id').value).to be_empty
 end
 
 Then(/^the default all value should be selected from Who They Help$/) do
-  expect(find("#who_id").value).to be_empty
+  expect(find('#who_id').value).to be_empty
 end
 
 Then(/^the default all value should be selected from How They Help$/) do
-  expect(find("#how_id").value).to be_empty
+  expect(find('#how_id').value).to be_empty
 end

--- a/features/step_definitions/contributors_steps.rb
+++ b/features/step_definitions/contributors_steps.rb
@@ -1,6 +1,6 @@
 Given(/^the following contributors exist:$/) do |contributors|
   @contributors = contributors.hashes
-  stub_request(:any, /api\.github\.com/).to_return(:body => @contributors.to_json)
+  stub_request(:any, /api\.github\.com/).to_return(body: @contributors.to_json)
 end
 
 

--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -1,13 +1,13 @@
 Then(/^I should see an approve cookie policy message$/) do
-  expect(page).to have_css("#cookie-message")
-  expect(page).to have_content("We use cookies to give you the best experience on our website")
-  expect(page).to have_xpath("//a[@id=\"accept_cookies\"]")
+  expect(page).to have_css('#cookie-message')
+  expect(page).to have_content('We use cookies to give you the best experience on our website')
+  expect(page).to have_xpath('//a[@id="accept_cookies"]')
   expect(page).to have_xpath("//a[@href=\"#{cookies_allow_path}\"]")
 end
 
 Then(/^I should not see an approve cookie policy message$/) do
-  page.should_not have_css("#cookie-message")
-  page.should_not have_content("We use cookies to give you the best experience on our website.")
-  page.should_not have_xpath("//a[@id=\"accept_cookies\"]")
+  page.should_not have_css('#cookie-message')
+  page.should_not have_content('We use cookies to give you the best experience on our website.')
+  page.should_not have_xpath('//a[@id="accept_cookies"]')
   page.should_not have_xpath("//a[@href=\"#{cookies_allow_path}\"]")
 end

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -1,15 +1,13 @@
 
 def expect_email_exists(message: nil, email: nil, link: nil, link_text: nil)
   #TODO: use mandatory keyword arguments, ie. message:, when upgrading to ruby 2.1
-  if message == nil || email == nil
-    raise "Must supply message and email address!"
-  end
+  raise 'Must supply message and email address!' if message.nil? || email.nil?
   mails = ActionMailer::Base.deliveries.select{|m| m.to.include? email}
   expect(mails).not_to be_empty
-  bodys = mails.map{|m| m.body}.select{|body| body.include? message }
+  bodys = mails.map(&:body).select{|body| body.include? message }
   expect(bodys).not_to be_empty
   if link && link_text
-    href = Nokogiri::HTML(bodys.first.raw_source).search("//a[text()='#{link_text}']")[0].attribute("href").value
+    href = Nokogiri::HTML(bodys.first.raw_source).search("//a[text()='#{link_text}']")[0].attribute('href').value
     expect(href).to eq link
   end
 end
@@ -19,7 +17,7 @@ And(/^an email should be sent to "(.*?)" as notice of becoming org admin of "(.*
   message = "You have been made an organisation admin for the organisation called #{org_name} on the Harrow Community Network. After logging in,
 you will be able to update your organisation's directory entry."
   expect_email_exists(message: message, email: email, link: organisation_url(Organisation.find_by(name: org_name)),
-                      link_text: "Click here to view your organisation on the Harrow Community Network.")
+                      link_text: 'Click here to view your organisation on the Harrow Community Network.')
 end
 
 And(/^an email should be sent to "(.*?)" as notification of the request for admin status of "(.*?)"$/) do |email, org_name|
@@ -41,8 +39,8 @@ Then(/^an email should be sent to "(.*?)" as notification of the proposed organi
   message = "A new organisation called #{proposed_org_fields[:name]} has been proposed for inclusion in the Harrow Community Network."
   expect_email_exists(message: message,email: email,
     link: proposed_organisation_url(ProposedOrganisation.find_by(name: proposed_org_fields[:name])),
-    link_text: "Click here to view this proposed organisation"
-  )
+    link_text: 'Click here to view this proposed organisation'
+                     )
 end
 
 And /^I should receive a "(.*?)" email$/ do |subj|
@@ -61,20 +59,20 @@ And /^the email queue is clear$/ do
 end
 
 Given(/^I run the fix invitations rake task$/) do
-  require "rake"
+  require 'rake'
   @rake = Rake::Application.new
   Rake.application = @rake
-  Rake.application.rake_require "tasks/fix_invites"
+  Rake.application.rake_require 'tasks/fix_invites'
   Rake::Task.define_task(:environment)
   @rake['db:fix_invites'].invoke
 end
 
 
 Given(/^I import emails from "(.*?)"$/) do |file|
-  require "rake"
+  require 'rake'
   @rake = Rake::Application.new
   Rake.application = @rake
-  Rake.application.rake_require "tasks/emails"
+  Rake.application.rake_require 'tasks/emails'
   Rake::Task.define_task(:environment)
   @rake['db:import:emails'].invoke(file)
 end

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -52,7 +52,7 @@ Then(/^I should see "(.*?)" description marker in "(.*?)" (event|organisation) l
   end
 end
 
-When("I click on the {string} text field") do |string|
+When('I click on the {string} text field') do |string|
   find(string).click
 end
 
@@ -68,12 +68,12 @@ end
 
 When(/^I edit with invalid details for "(.*)"/) do |event|
   event = Event.find_by(title: event)
-  fill_in "event_title", with: ""
-  click_button("Update Event")
+  fill_in 'event_title', with: ''
+  click_button('Update Event')
 end
 
 When(/^I edit the details for "(.*)"/) do |event|
   event = Event.find_by(title: event)
-  fill_in "event_title", with: "Lazier Weekend"
-  click_button("Update Event")
+  fill_in 'event_title', with: 'Lazier Weekend'
+  click_button('Update Event')
 end

--- a/features/step_definitions/factory_steps.rb
+++ b/features/step_definitions/factory_steps.rb
@@ -29,18 +29,18 @@ end
 
 def expect_proposed_org_is_notified(acceptance_message, email, org)
   expect_email_exists(
-    :message   => acceptance_message,
-    :email     => email,
-    :link      => organisation_url(org),
-    :link_text => 'You can edit your organisation details by logging in and editing it directly.'
+    message: acceptance_message,
+    email: email,
+    link: organisation_url(org),
+    link_text: 'You can edit your organisation details by logging in and editing it directly.'
   )
   expect(org.users.pluck(:email)).to include(email)
 end
 
 def expect_proposed_org_is_invited(acceptance_message, email, org)
   expect_email_exists(
-    :message => acceptance_message,
-    :email   => email,
+    message: acceptance_message,
+    email: email,
   )
   expect(org.users.pluck(:email)).to include(email)
 end
@@ -70,14 +70,14 @@ Then(/^I should see the details of the proposed organisation$/) do
   [:name, :description, :email, :address, :postcode].each do |key|
     expect(page).to have_content unsaved_proposed_organisation[key]
   end
-  ["Donate to Friendly Charity now!", 'We are a not for profit organisation registered or working in Harrow'].each do |value|
+  ['Donate to Friendly Charity now!', 'We are a not for profit organisation registered or working in Harrow'].each do |value|
       expect(page).to have_content value
   end
 end
 
 Given /^the following organisations exist:$/ do |organisations_table|
   organisations_table.hashes.each do |org|
-    VCR.use_cassette("#{org["name"]}-#{org["postcode"]}") do
+    VCR.use_cassette("#{org['name']}-#{org['postcode']}") do
       organisation = Organisation.new(org)
       organisation.check_geocode
       organisation.save!
@@ -87,16 +87,16 @@ end
 
 Given /^the following users are registered:$/ do |users_table|
   users_table.hashes.each do |user|
-    user["superadmin"] = user["superadmin"] == "true"
-    user["organisation"] = Organisation.find_by_name(user["organisation"])
-    user["pending_organisation"] = Organisation.find_by_name(user["pending_organisation"])
+    user['superadmin'] = user['superadmin'] == 'true'
+    user['organisation'] = Organisation.find_by_name(user['organisation'])
+    user['pending_organisation'] = Organisation.find_by_name(user['pending_organisation'])
     User.create! user
   end
 end
 
 Given /the following volunteer opportunities exist/ do |volunteer_ops_table|
   volunteer_ops_table.hashes.each do |volunteer_op|
-    volunteer_op["organisation"] = Organisation.find_by_name(volunteer_op["organisation"])
+    volunteer_op['organisation'] = Organisation.find_by_name(volunteer_op['organisation'])
     VolunteerOp.create! volunteer_op
   end
 end
@@ -138,14 +138,14 @@ end
 
 When(/^a static page named "(.*?)" with permalink "(.*?)" and markdown content:$/) \
 do |name, permalink, content|
-  Page.create!(:name => name,
-               :permalink => permalink,
-               :content => content,
-               :link_visible => true)
+  Page.create!(name: name,
+               permalink: permalink,
+               content: content,
+               link_visible: true)
 end
 
 And(/^a file exists:$/) do |table|
-  CSV.open("db/email_test.csv", "wb") do |csv|
+  CSV.open('db/email_test.csv', 'wb') do |csv|
     csv << table.hashes[0].keys
     table.hashes.each do |org|
       csv << org.values

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -43,7 +43,7 @@ Given (/^reachskills opportunities are imported with nil coordinates$/) do
   ImportReachSkillsVolunteerOpportunities.with
 end
 
-Then("there should be zero nil coordinates") do
+Then('there should be zero nil coordinates') do
   expect(VolunteerOp.where(latitude: nil).count).to eq 0
   expect(VolunteerOp.where(longitude: nil).count).to eq 0
 end
@@ -54,7 +54,7 @@ Then (/^(\d+) default Harrow coordinates should be assigned$/) do |num_coords|
 end
 
 def check_for_org_info_box tbl, selector
-  expect(page).to have_css(selector, :count => tbl.length)
+  expect(page).to have_css(selector, count: tbl.length)
   Organisation.where(name: tbl)
         .pluck(:name, :description, :id, :slug)
         .map {|name, desc, id, frdly_id| [name, smart_truncate(desc, 44), id, frdly_id]}
@@ -71,8 +71,10 @@ end
 def check_for_volop_info_box(tbl, selector, check_tbl_length = true)
   expect(page).to have_css(selector, count: tbl.length) if check_tbl_length
   VolunteerOp.where(title: tbl)
-        .map {|volop| [volop.id, volop.organisation.name, volop.title,
-          smart_truncate(volop.description, 44), volop.organisation.slug]}
+        .map do |volop| 
+    [volop.id, volop.organisation.name, volop.title,
+          smart_truncate(volop.description, 44), volop.organisation.slug]
+  end  
         .each do |id, name, title, desc, org_friendly_id|
       all(selector).map do |list_item|
         list_item.trigger(:mouseover) if list_item.first('a').text == title
@@ -87,9 +89,11 @@ end
 
 def check_info_box_link_opens_in_new_page(tbl, selector)
   VolunteerOp.where(title: tbl)
-      .map {|volop| [volop.id, volop.organisation.name, volop.title,
-                     smart_truncate(volop.description, 44), volop.organisation.slug]}
-      .each do |id, name, title, desc, org_friendly_id|
+      .map do |volop| 
+    [volop.id, volop.organisation.name, volop.title,
+                     smart_truncate(volop.description, 44), volop.organisation.slug]
+  end  
+      .each do |_id, name, title, _desc, _org_friendly_id|
     all(selector).map do |list_item|
       list_item.trigger(:mouseover) if list_item.first('a').text == title
     end
@@ -102,7 +106,7 @@ def check_for_no_org_info_box(tbl, selector, check_tbl_length = true)
   Organisation.where(name: tbl)
         .pluck(:name, :description, :id, :slug)
         .map {|name, desc, id, frdly_id| [name, smart_truncate(desc, 42), id, frdly_id]}
-        .each do |name, desc, id, friendly_id|
+        .each do |name, desc, _id, _friendly_id|
       find(selector).trigger(:mouseleave)
       expect(page).not_to have_css('.arrow_box')
       expect(find('.arrow_box')).not_to have_content(desc)
@@ -128,25 +132,25 @@ end
 
 Then /^the (proposed organisation|organisation) "(.*?)" should have a (large|small) icon$/ do |type, name, icon_size|
   klass = case type
-  when 'proposed organisation'
+          when 'proposed organisation'
     ProposedOrganisation
-  when 'organisation'
+          when 'organisation'
     Organisation
   else
     raise "Unknown class #{type}"
   end
   org_id = klass.find_by(name: name).id
-  marker_class = (icon_size == "small") ? "measle" : "marker"
-  if marker_class == "measle"
-    expect(find_map_icon(marker_class, org_id)["src"]).to match /\/assets\/measle-(\w*)\.png$/ix
+  marker_class = (icon_size == 'small') ? 'measle' : 'marker'
+  if marker_class == 'measle'
+    expect(find_map_icon(marker_class, org_id)['src']).to match /\/assets\/measle-(\w*)\.png$/ix
   else
-    expect(find_map_icon(marker_class, org_id)["src"]).to match /\/assets\/marker-(\w*)\.png$/ix
+    expect(find_map_icon(marker_class, org_id)['src']).to match /\/assets\/marker-(\w*)\.png$/ix
   end
 end
 
 Then /^I should( not)? see the following (measle|vol_op|event) markers in the map:$/ do |negative, klass, table|
   klass_hash = {'measle' => '.measle', 'vol_op' => '.vol_op', 'event' => '.vol_op'}
-  expect(page).to have_css(klass_hash[klass], :count => table.raw.flatten.length)
+  expect(page).to have_css(klass_hash[klass], count: table.raw.flatten.length)
   marker_data = page.find('#marker_data')['data-markers']
   table.raw.flatten do |title|
     if negative
@@ -199,8 +203,8 @@ end
 
 Then /^I should see search results for "(.*?)" in the table$/ do |search_terms|
   orgs = Organisation.search_by_keyword(search_terms)
-  orgs.each do |org|
-    matches = page.html.match %Q<{\\"description\\":\\".*>#{org.name}</a>.*\\",\\"lat\\":((?:-|)\\d+\.\\d+),\\"lng\\":((?:-|)\\d+\.\\d+)}>
+  orgs.each do |_org|
+    matches = page.html.match %({\\"description\\":\\".*)#{org.name}</a>.*\\",\\"lat\\":((?:-|)\\d+\.\\d+),\\"lng\\":((?:-|)\\d+\.\\d+)}>
     expect(matches).not_to be_nil
   end
 end
@@ -219,7 +223,7 @@ def stub_request_with_address(address, body = nil)
 end
 
 Given /Google is indisposed for "(.*)"/ do  |address|
-  body = %Q({
+  body = %({
 "results" : [],
 "status" : "OVER_QUERY_LIMIT"
 })

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -56,61 +56,61 @@ end
 def check_for_org_info_box tbl, selector
   expect(page).to have_css(selector, count: tbl.length)
   Organisation.where(name: tbl)
-        .pluck(:name, :description, :id, :slug)
-        .map {|name, desc, id, frdly_id| [name, smart_truncate(desc, 44), id, frdly_id]}
-        .each do |name, desc, id, friendly_id|
-      click_map_icon(id)
-      expect(page).to have_css('.arrow_box')
-      expect(find('.arrow_box')).to have_content(desc)
-      expect(find('.arrow_box')).to have_content(name)
-      link = find('.arrow_box').find('a')[:href]
-      expect(link).to end_with(organisation_path(friendly_id))
+    .pluck(:name, :description, :id, :slug)
+    .map {|name, desc, id, frdly_id| [name, smart_truncate(desc, 44), id, frdly_id]}
+    .each do |name, desc, id, friendly_id|
+    click_map_icon(id)
+    expect(page).to have_css('.arrow_box')
+    expect(find('.arrow_box')).to have_content(desc)
+    expect(find('.arrow_box')).to have_content(name)
+    link = find('.arrow_box').find('a')[:href]
+    expect(link).to end_with(organisation_path(friendly_id))
   end
 end
 
 def check_for_volop_info_box(tbl, selector, check_tbl_length = true)
   expect(page).to have_css(selector, count: tbl.length) if check_tbl_length
   VolunteerOp.where(title: tbl)
-        .map do |volop| 
+    .map do |volop|
     [volop.id, volop.organisation.name, volop.title,
-          smart_truncate(volop.description, 44), volop.organisation.slug]
-  end  
-        .each do |id, name, title, desc, org_friendly_id|
+     smart_truncate(volop.description, 44), volop.organisation.slug]
+    end
+    .each do |id, name, title, desc, org_friendly_id|
       all(selector).map do |list_item|
         list_item.trigger(:mouseover) if list_item.first('a').text == title
       end
-      expect(page).to have_css('.arrow_box')
-      expect(find('.arrow_box')).to have_content(desc)
-      expect(find('.arrow_box')).to have_content(name)
-      expect(find('.arrow_box').first('a', text: name)[:href]).to end_with(org_friendly_id)
-      expect(find('.arrow_box').first('a', text: title)[:href]).to end_with(id.to_s)
-  end
+    expect(page).to have_css('.arrow_box')
+    expect(find('.arrow_box')).to have_content(desc)
+    expect(find('.arrow_box')).to have_content(name)
+    expect(find('.arrow_box').first('a', text: name)[:href]).to end_with(org_friendly_id)
+    expect(find('.arrow_box').first('a', text: title)[:href]).to end_with(id.to_s)
+    end
 end
 
 def check_info_box_link_opens_in_new_page(tbl, selector)
   VolunteerOp.where(title: tbl)
-      .map do |volop| 
-    [volop.id, volop.organisation.name, volop.title,
-                     smart_truncate(volop.description, 44), volop.organisation.slug]
-  end  
-      .each do |_id, name, title, _desc, _org_friendly_id|
-    all(selector).map do |list_item|
-      list_item.trigger(:mouseover) if list_item.first('a').text == title
+    .map do |volop|
+      [ volop.id, volop.organisation.name, volop.title,
+        smart_truncate(volop.description, 44), volop.organisation.slug ]
     end
-    expect { click_link(name) }.to change(&number_of_windows).by 1
-  end
+    .each do |_id, name, title, _desc, _org_friendly_id|
+      all(selector).map do |list_item|
+        list_item.trigger(:mouseover) if list_item.first('a').text == title
+      end
+      expect { click_link(name) }.to change(&number_of_windows).by 1
+    end
 end
 
 def check_for_no_org_info_box(tbl, selector, check_tbl_length = true)
   expect(page).to have_css(selector, count: tbl.length) if check_tbl_length
   Organisation.where(name: tbl)
-        .pluck(:name, :description, :id, :slug)
-        .map {|name, desc, id, frdly_id| [name, smart_truncate(desc, 42), id, frdly_id]}
-        .each do |name, desc, _id, _friendly_id|
-      find(selector).trigger(:mouseleave)
-      expect(page).not_to have_css('.arrow_box')
-      expect(find('.arrow_box')).not_to have_content(desc)
-      expect(find('.arrow_box')).not_to have_content(name)
+    .pluck(:name, :description, :id, :slug)
+    .map {|name, desc, id, frdly_id| [name, smart_truncate(desc, 42), id, frdly_id]}
+    .each do |name, desc, _id, _friendly_id|
+    find(selector).trigger(:mouseleave)
+    expect(page).not_to have_css('.arrow_box')
+    expect(find('.arrow_box')).not_to have_content(desc)
+    expect(find('.arrow_box')).not_to have_content(name)
   end
 end
 
@@ -131,14 +131,15 @@ def find_map_icon klass, org_id
 end
 
 Then /^the (proposed organisation|organisation) "(.*?)" should have a (large|small) icon$/ do |type, name, icon_size|
-  klass = case type
-          when 'proposed organisation'
-    ProposedOrganisation
-          when 'organisation'
-    Organisation
-  else
-    raise "Unknown class #{type}"
-  end
+  klass =
+    case type
+    when 'proposed organisation'
+      ProposedOrganisation
+    when 'organisation'
+      Organisation
+    else
+      raise "Unknown class #{type}"
+    end
   org_id = klass.find_by(name: name).id
   marker_class = (icon_size == 'small') ? 'measle' : 'marker'
   if marker_class == 'measle'
@@ -157,7 +158,7 @@ Then /^I should( not)? see the following (measle|vol_op|event) markers in the ma
       expect(marker_data).not_to include(title)
     else
       expect(marker_data).to include(title)
-     end
+    end
   end
 end
 
@@ -172,10 +173,10 @@ def markers
 end
 
 def marker_json_for_org_names(*org_names)
-    marker_json = JSON.parse markers
-    [*org_names].map do |name|
-      marker_json.find{|m| m['infowindow'].include? name }
-    end
+  marker_json = JSON.parse markers
+  [*org_names].map do |name|
+    marker_json.find{|m| m['infowindow'].include? name }
+  end
 end
 
 Then /^the coordinates for "(.*?)" should( not)? be "(.*?), (.*?)"/ do | org1_name, negation, lat, lng |
@@ -236,8 +237,9 @@ And(/^"(.*?)" should not have nil coordinates$/) do |name|
   org.longitude.should_not be_nil
 end
 
-GMAPS_URL_KEY_NIL = 'https://maps.google.com/maps/api/js?' +
-                    'v=3&libraries=geometry&key='.freeze
+GMAPS_URL_KEY_NIL =
+  'https://maps.google.com/maps/api/js?' +
+  'v=3&libraries=geometry&key='.freeze
 
 Then(/^the google map key should( not)? be appended to the gmap js script$/) do |negation|
   script_css = "script[src='#{GMAPS_URL_KEY_NIL}#{ENV['GMAP_API_KEY']}']"

--- a/features/step_definitions/moderate_proposed_organisation_edit_steps.rb
+++ b/features/step_definitions/moderate_proposed_organisation_edit_steps.rb
@@ -1,5 +1,5 @@
 Given(/^I click on the pending proposed edits link$/) do
-  click_link "Pending Proposed Edits"
+  click_link 'Pending Proposed Edits'
 end
 
 Then(/^I should not see the pending proposed edits link$/) do
@@ -8,12 +8,12 @@ end
 
 Given(/^I click on view details for the proposed edit for the organisation named "(.*?)"$/) do |org_name|
   edit = ProposedOrganisationEdit.find_by(archived: false, organisation: Organisation.find_by(name: org_name))
-  click_link "View Details", href: organisation_proposed_organisation_edit_path(edit.organisation, edit)
+  click_link 'View Details', href: organisation_proposed_organisation_edit_path(edit.organisation, edit)
 end
 
 Then(/^"(.*?)" should be updated as follows:$/) do |org, table|
   expect(Organisation.find_by(name: org)).to be_nil
-  organisation = Organisation.find_by(name: table.hashes.first["name"])
+  organisation = Organisation.find_by(name: table.hashes.first['name'])
   table.hashes.each do |hash|
     hash.each_pair do |field_name, field_value|
       expect(organisation.send(field_name)).to eq(field_value)
@@ -44,6 +44,6 @@ end
 
 Then(/^I should see a view details link for each of the proposed organisations$/) do
   ProposedOrganisation.all.each do |proposed_org|
-    expect(page).to have_link "View Details", href: proposed_organisation_path(proposed_org)
+    expect(page).to have_link 'View Details', href: proposed_organisation_path(proposed_org)
   end
 end

--- a/features/step_definitions/moderate_proposed_organisation_steps.rb
+++ b/features/step_definitions/moderate_proposed_organisation_steps.rb
@@ -1,8 +1,8 @@
 Then (/^I should( not)? see an "Accept Proposed Organisation" button$/) do |negation|
   if negation
-    expect(page).not_to have_button "Accept"
+    expect(page).not_to have_button 'Accept'
   else
-      expect(page).to have_button "Accept"
+      expect(page).to have_button 'Accept'
   end
 end
 
@@ -21,22 +21,22 @@ end
 
 Then (/^I should( not)? see a "Reject Proposed Organisation" button$/) do |negation|
   if negation
-    expect(page).not_to have_button "Reject"
+    expect(page).not_to have_button 'Reject'
   else
-    expect(page).to have_button "Reject"
+    expect(page).to have_button 'Reject'
   end
 end
 
 Then(/^I click on the pending proposed organisations link$/) do
-  click_link "Pending Proposed Organisations"
+  click_link 'Pending Proposed Organisations'
 end
 
 Then (/^I should not see an add organisation link$/) do
-  expect(page).to_not have_link("Add Organisation", href: new_proposed_organisation_path)
+  expect(page).to_not have_link('Add Organisation', href: new_proposed_organisation_path)
 end
 
 Then(/^I should be on the show page for the organisation that was proposed$/) do
-  steps %{Then I should be on the show page for the organisation named "#{unsaved_proposed_organisation.name}"}
+  steps %(Then I should be on the show page for the organisation named "#{unsaved_proposed_organisation.name}")
 end
 
 Then(/^the proposed organisation should have been rejected$/) do

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,16 +1,16 @@
 
 And /^I select the "(.*?)" category from (How They Help|Who They Help|What They Do)$/ do |category, cat_type|
   cat_id = case cat_type
-    when 'What They Do'
+           when 'What They Do'
       'what_id'
-    when 'How They Help'
+           when 'How They Help'
       'how_id'
-    when 'Who They Help'
+           when 'Who They Help'
       'who_id'
     else
-      raise "Unsupported category type"
+      raise 'Unsupported category type'
   end
-  select(category, :from => cat_id)
+  select(category, from: cat_id)
 end
 
 When /^I visit the proposed organisation show page for the proposed organisation that was proposed$/ do
@@ -53,8 +53,8 @@ Then /^I (visit|should be on) the (.*) page$/ do |mode, location|
   location.downcase!
   raise "No matching path found for #{location}" if paths(location).nil?
   case mode
-    when 'visit' then visit paths(location)
-    when 'should be on' then current_path.should eq paths(location)
+  when 'visit' then visit paths(location)
+  when 'should be on' then current_path.should eq paths(location)
     else raise "unknown mode '#{mode}'"
   end
 end
@@ -83,8 +83,8 @@ Then /^I (visit|should be on) the new volunteer op page for "(.*?)"$/ do |mode, 
   org = Organisation.find_by_name(name)
   url = new_organisation_volunteer_op_path(org)
   case mode
-    when 'visit' then visit url
-    when 'should be on' then current_path.should eq url
+  when 'visit' then visit url
+  when 'should be on' then current_path.should eq url
     else raise "unknown mode '#{mode}'"
   end
 end
@@ -96,10 +96,10 @@ Then /^I (visit|should be on) the (edit|show) page for the (.*?) (named|titled) 
       controller: object.pluralize.underscore,
       action: action,
       id: record
-  )
+    )
   case mode
-    when 'visit' then visit url
-    when 'should be on' then current_path.should eq url
+  when 'visit' then visit url
+  when 'should be on' then current_path.should eq url
     else raise "unknown mode '#{mode}'"
   end
 end
@@ -136,7 +136,7 @@ end
 When /^I click "(.*)" (.*) link$/ do |link, position|
   case position
   when 'breadcrumb'
-    click_link(link, :match => :first)
+    click_link(link, match: :first)
   when 'organisation'
     within('#column2') do
        click_on link
@@ -154,11 +154,11 @@ When /^(?:|I )follow "([^"]*)"$/ do |link|
 end
 
 Then /^following Disclaimer link should display Disclaimer$/ do
-  steps %Q{
+  steps %(
 When I follow "Disclaimer"
 Then I should see "Disclaimer"
 And I should see "Whilst Voluntary Action Harrow has made effort to ensure the information here is accurate and up to date we are reliant on the information provided by the different organisations. No guarantees for the accuracy of the information is made."
-}
+)
 end
 
 Then(/^the "([^"]*)" should be (not )?visible$/) do |id, negate|
@@ -178,14 +178,14 @@ When(/^javascript is enabled$/) do
 end
 
 And(/^I click tableheader "([^"]*)"$/) do |name|
-  find('th', :text => "#{name}").click
+  find('th', text: "#{name}").click
   wait_for_ajax
 end
 
 Then(/^navbar button "(.*?)" should( not)? be active$/) do |button_text, negative|
   expectation_method = negative ? :should_not : :should
   within('.nav.nav-pills.pull-right') do
-    page.send(expectation_method, have_css('li.active > a', :text => "#{button_text}"))
+    page.send(expectation_method, have_css('li.active > a', text: "#{button_text}"))
   end
 end
 
@@ -199,27 +199,27 @@ Then(/^the page includes email hyperlink "([^"]*)"$/) do  |link|
 end
 
 Then(/^I should see "([^"]*)" in the flash error$/) do |message|
-  page.should have_css('div#flash_error', :text => message)
+  page.should have_css('div#flash_error', text: message)
 end
 
 Then(/^I should see "([^"]*)" in the flash$/) do |message|
-  page.should have_css('div#flash_success.alert-success', :text => message)
+  page.should have_css('div#flash_success.alert-success', text: message)
 end
 
 Then(/^I should( not)? see the call to update details for organisation "(.*)"/) do |negative, org_name|
     org = Organisation.find_by_name org_name
     expectation_method = negative ? :should_not : :should
-    message = "You have not updated your details in over a year! Please click here to update now."
-    page.send(expectation_method, have_css('div#flash_warning', :text => message))
+    message = 'You have not updated your details in over a year! Please click here to update now.'
+    page.send(expectation_method, have_css('div#flash_warning', text: message))
 
     within(negative.nil? ? 'div#flash_warning' : 'body') do
-      page.send(expectation_method, have_link("here", :href => edit_organisation_path(org)))
+      page.send(expectation_method, have_link('here', href: edit_organisation_path(org)))
     end
 end
 Then(/^I should see an (active|inactive) home button in the header$/) do |active|
-    active_class = (active == "active") ? ".active" : ""
+    active_class = (active == 'active') ? '.active' : ''
     within('.nav.nav-pills.pull-right') do
-      expect(page).to have_css("li#{active_class} > a[href='/']", :text => "Home")
+      expect(page).to have_css("li#{active_class} > a[href='/']", text: 'Home')
     end
 end
 
@@ -229,24 +229,24 @@ Then(/^I should see link "([^"]*)" targeting new page$/) do |link_name|
 end
 
 When(/^I click column header "([^"]*)"$/) do |val|
-  find('th', :text => val).click()
+  find('th', text: val).click
 end
 
-When("I click on {string} for the user {string}") do |text, email|
+When('I click on {string} for the user {string}') do |text, email|
   user_id = User.find_by_email(email).id
   within("tr##{user_id}") do
-    step %{I click "#{text}"}
+    step %(I click "#{text}")
   end
 end
 
-Given("I visit {string} organisation page") do |name|
+Given('I visit {string} organisation page') do |name|
   id = Organisation.find_by(name: name).id
-  visit organisation_path(:id => id)
+  visit organisation_path(id: id)
 end
 
-Given("I visit {string} organisation propose edit page") do |name|
+Given('I visit {string} organisation propose edit page') do |name|
   id = Organisation.find_by(name: name).id
-  visit new_organisation_proposed_organisation_edit_path :organisation_id => id
+  visit new_organisation_proposed_organisation_edit_path organisation_id: id
 end
 
 Given(/^I am not logged in as any user/) do

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,15 +1,15 @@
-
 And /^I select the "(.*?)" category from (How They Help|Who They Help|What They Do)$/ do |category, cat_type|
-  cat_id = case cat_type
-           when 'What They Do'
+  cat_id =
+    case cat_type
+    when 'What They Do'
       'what_id'
-           when 'How They Help'
+    when 'How They Help'
       'how_id'
-           when 'Who They Help'
+    when 'Who They Help'
       'who_id'
     else
       raise 'Unsupported category type'
-  end
+    end
   select(category, from: cat_id)
 end
 
@@ -22,7 +22,7 @@ When(/^I visit "(.*?)"$/) do |path|
   visit path
 end
 
-def paths(location)
+def paths(location) #rubocop:disable Metrics/MethodLength
   reset_pwd = "#{edit_user_password_path}?reset_password_token=#{@reset_password_token}"
   {
     'home' => root_path,
@@ -55,7 +55,7 @@ Then /^I (visit|should be on) the (.*) page$/ do |mode, location|
   case mode
   when 'visit' then visit paths(location)
   when 'should be on' then current_path.should eq paths(location)
-    else raise "unknown mode '#{mode}'"
+  else raise "unknown mode '#{mode}'"
   end
 end
 
@@ -85,22 +85,22 @@ Then /^I (visit|should be on) the new volunteer op page for "(.*?)"$/ do |mode, 
   case mode
   when 'visit' then visit url
   when 'should be on' then current_path.should eq url
-    else raise "unknown mode '#{mode}'"
+  else raise "unknown mode '#{mode}'"
   end
 end
 
 Then /^I (visit|should be on) the (edit|show) page for the (.*?) (named|titled) "(.*?)"$/ do |mode, action, object, schema, name|
   record = find_record_for(object, schema, name)
   url = url_for(
-      only_path: true,
-      controller: object.pluralize.underscore,
-      action: action,
-      id: record
-    )
+    only_path: true,
+    controller: object.pluralize.underscore,
+    action: action,
+    id: record
+  )
   case mode
   when 'visit' then visit url
   when 'should be on' then current_path.should eq url
-    else raise "unknown mode '#{mode}'"
+  else raise "unknown mode '#{mode}'"
   end
 end
 
@@ -139,7 +139,7 @@ When /^I click "(.*)" (.*) link$/ do |link, position|
     click_link(link, match: :first)
   when 'organisation'
     within('#column2') do
-       click_on link
+      click_on link
     end
   end
 end
@@ -158,7 +158,7 @@ Then /^following Disclaimer link should display Disclaimer$/ do
 When I follow "Disclaimer"
 Then I should see "Disclaimer"
 And I should see "Whilst Voluntary Action Harrow has made effort to ensure the information here is accurate and up to date we are reliant on the information provided by the different organisations. No guarantees for the accuracy of the information is made."
-)
+  )
 end
 
 Then(/^the "([^"]*)" should be (not )?visible$/) do |id, negate|
@@ -207,25 +207,25 @@ Then(/^I should see "([^"]*)" in the flash$/) do |message|
 end
 
 Then(/^I should( not)? see the call to update details for organisation "(.*)"/) do |negative, org_name|
-    org = Organisation.find_by_name org_name
-    expectation_method = negative ? :should_not : :should
-    message = 'You have not updated your details in over a year! Please click here to update now.'
-    page.send(expectation_method, have_css('div#flash_warning', text: message))
+  org = Organisation.find_by_name org_name
+  expectation_method = negative ? :should_not : :should
+  message = 'You have not updated your details in over a year! Please click here to update now.'
+  page.send(expectation_method, have_css('div#flash_warning', text: message))
 
-    within(negative.nil? ? 'div#flash_warning' : 'body') do
-      page.send(expectation_method, have_link('here', href: edit_organisation_path(org)))
-    end
+  within(negative.nil? ? 'div#flash_warning' : 'body') do
+    page.send(expectation_method, have_link('here', href: edit_organisation_path(org)))
+  end
 end
 Then(/^I should see an (active|inactive) home button in the header$/) do |active|
-    active_class = (active == 'active') ? '.active' : ''
-    within('.nav.nav-pills.pull-right') do
-      expect(page).to have_css("li#{active_class} > a[href='/']", text: 'Home')
-    end
+  active_class = (active == 'active') ? '.active' : ''
+  within('.nav.nav-pills.pull-right') do
+    expect(page).to have_css("li#{active_class} > a[href='/']", text: 'Home')
+  end
 end
 
 Then(/^I should see link "([^"]*)" targeting new page$/) do |link_name|
-     target_link = find_link(link_name)
-     expect(target_link[:target]).to eq '_blank'
+  target_link = find_link(link_name)
+  expect(target_link[:target]).to eq '_blank'
 end
 
 When(/^I click column header "([^"]*)"$/) do |val|

--- a/features/step_definitions/organisation_reports/undo_user_delete_steps.rb
+++ b/features/step_definitions/organisation_reports/undo_user_delete_steps.rb
@@ -1,7 +1,7 @@
 Then(/^I restore the user with the email "(.*?)"$/) do |usr_email|
   id = User.only_deleted.where(email: usr_email).first.id
   within("tr##{id}") do
-    click_link "Restore User"
+    click_link 'Restore User'
   end
 end
 
@@ -13,5 +13,5 @@ Then(/^the user with email "(.*?)" should( not)? be displayed on the all deleted
 end
 
 Given(/^I click on the deleted users link$/) do
-  click_link "Deleted Users"
+  click_link 'Deleted Users'
 end

--- a/features/step_definitions/organisation_reports/without_users_steps.rb
+++ b/features/step_definitions/organisation_reports/without_users_steps.rb
@@ -2,7 +2,7 @@ Then(/^I should see "([^"]*)" in the response field for "([^"]*)"$/) do |msg, or
   org = Organisation.find_by_name(org_name)
   id = org.id
   response = within("##{id}") { find('.response') }
-  raise "Expected '#{msg}' but instead found '#{response.text}'" unless (response.text == msg)
+  raise "Expected '#{msg}' but instead found '#{response.text}'" unless response.text == msg
 end
 
 Given(/^I check the box for "(.*?)"$/) do |org_name|
@@ -20,12 +20,12 @@ Given(/^the superadmin invited a user for "(.*?)"$/) do |organisation_name|
   current_user = User.find_by_superadmin true
   org = Organisation.find_by_name(organisation_name)
   params = {
-      :resend_invitation => 'true',
-      :invite_list => {org.id => org.email}
+      resend_invitation: 'true',
+      invite_list: {org.id => org.email}
   }
   BatchInviteJob.new(params, current_user).run
 end
 
 Then(/^I should see the preview email$/) do
-  expect(page).to have_content "The Following email will be sent when a user is invited:"
+  expect(page).to have_content 'The Following email will be sent when a user is invited:'
 end

--- a/features/step_definitions/post_to_doit_steps.rb
+++ b/features/step_definitions/post_to_doit_steps.rb
@@ -1,5 +1,5 @@
-Given "I submit a volunteer op with an arbitrary string" do
-  org = Organisation.find_by_name("Friendly")
+Given 'I submit a volunteer op with an arbitrary string' do
+  org = Organisation.find_by_name('Friendly')
   visit new_organisation_volunteer_op_path org
   check 'volunteer_op[post_to_doit]', id: 'check_to_doit'
   fill_in 'volunteer_op[advertise_start_date]', with: 'now'
@@ -7,8 +7,8 @@ Given "I submit a volunteer op with an arbitrary string" do
   click_on 'Create a Volunteer Opportunity'
 end
 
-Given "I submit a volunteer op with a start date in the past" do
-  org = Organisation.find_by_name("Friendly")
+Given 'I submit a volunteer op with a start date in the past' do
+  org = Organisation.find_by_name('Friendly')
   visit new_organisation_volunteer_op_path org
   check 'volunteer_op[post_to_doit]', id: 'check_to_doit'
   fill_in 'volunteer_op[advertise_start_date]', with: '1999-12-31'
@@ -16,8 +16,8 @@ Given "I submit a volunteer op with a start date in the past" do
   click_on 'Create a Volunteer Opportunity'
 end
 
-Given "I submit a volunteer op with an end date before the start date" do
-  org = Organisation.find_by_name("Friendly")
+Given 'I submit a volunteer op with an end date before the start date' do
+  org = Organisation.find_by_name('Friendly')
   visit new_organisation_volunteer_op_path org
   check 'volunteer_op[post_to_doit]', id: 'check_to_doit'
   fill_in 'volunteer_op[advertise_start_date]', with: '1999-12-31'
@@ -25,8 +25,8 @@ Given "I submit a volunteer op with an end date before the start date" do
   click_on 'Create a Volunteer Opportunity'
 end
 
-Given "I submit a volunteer op with valid dates" do
-  org = Organisation.find_by_name("Friendly")
+Given 'I submit a volunteer op with valid dates' do
+  org = Organisation.find_by_name('Friendly')
   visit new_organisation_volunteer_op_path org
   check 'volunteer_op[post_to_doit]', id: 'check_to_doit'
   fill_in 'volunteer_op[advertise_start_date]', with: Date.current.strftime('%Y-%m-%d')
@@ -34,7 +34,7 @@ Given "I submit a volunteer op with valid dates" do
   click_on 'Create a Volunteer Opportunity'
 end
 
-Then "I should not see {string} and {string}" do |text1, text2|
+Then 'I should not see {string} and {string}' do |text1, text2|
   expect(page).not_to have_content text1
   expect(page).not_to have_content text2
 end

--- a/features/step_definitions/proposed_organisation_edit_steps.rb
+++ b/features/step_definitions/proposed_organisation_edit_steps.rb
@@ -14,7 +14,7 @@ Then(/^the telephone field of the proposed edit should be pre\-populated with th
 end
 
 Given(/^the (.*) field is marked (private|public)$/) do |field, visibility|
-  if visibility == "private"
+  if visibility == 'private'
     expect(page.find(:xpath, "//input[@id='proposed_organisation_edit_#{field}']/../../td[@class='borderless']/input[@type='checkbox']")).not_to be_checked
   else
     expect(page.find(:xpath, "//input[@id='proposed_organisation_edit_#{field}']/../../td[@class='borderless']/input[@type='checkbox']")).to be_checked
@@ -38,7 +38,7 @@ When(/^I propose the following edit:$/) do |table|
                donation_info: 'proposed_organisation_edit_donation_info',
                address: 'proposed_organisation_edit_address'}
     hash.each_pair do |field_name, field_value|
-      fill_in(fields[field_name.to_sym],:with => field_value)
+      fill_in(fields[field_name.to_sym],with: field_value)
     end
   end
 end
@@ -60,16 +60,16 @@ Then(/^the following proposed edits should be displayed on the page:$/) do |tabl
     proposed_class = '.proposed_organisation_' + hash['field']
     expect(page).to have_css("#{current_class}.current_value")
     expect(page).to have_css("#{proposed_class}.proposed_value")
-    if (hash['field'] == 'website')
+    if hash['field'] == 'website'
       if hash['current value'].blank?
-        expect(page).not_to have_css(current_class + " .field_value a")
+        expect(page).not_to have_css(current_class + ' .field_value a')
       else
-        expect(page).to have_css current_class + " .field_value a"
+        expect(page).to have_css current_class + ' .field_value a'
       end
       if hash['proposed value'].blank?
-        expect(page).not_to have_css(proposed_class + " .field_value a")
+        expect(page).not_to have_css(proposed_class + ' .field_value a')
       else
-        expect(page).to have_css proposed_class + " .field_value a"
+        expect(page).to have_css proposed_class + ' .field_value a'
       end
     end
     if hash['field'] == 'description'
@@ -92,9 +92,9 @@ Given(/^the following proposed edits exist:$/) do |table|
     create_hash = {}
     hash.each_pair do |field_name, field_value|
       key_value_to_add = {field_name.to_sym => field_value}
-      key_value_to_add = {editor: User.find_by(email: field_value)} if field_name == "editor_email"
-      key_value_to_add = {organisation: Organisation.find_by(name: field_value)} if field_name == "original_name"
-      key_value_to_add = {archived: Boolean.from(field_value)} if field_name == "archived"
+      key_value_to_add = {editor: User.find_by(email: field_value)} if field_name == 'editor_email'
+      key_value_to_add = {organisation: Organisation.find_by(name: field_value)} if field_name == 'original_name'
+      key_value_to_add = {archived: Boolean.from(field_value)} if field_name == 'archived'
       create_hash.merge! key_value_to_add
     end
     ProposedOrganisationEdit.create! create_hash
@@ -103,7 +103,7 @@ end
 
 Then(/^I should not see links for archived edits$/) do
   ProposedOrganisationEdit.where(archived: true).each do |archived_edit|
-    expect(page).not_to have_link "View Details", href: organisation_proposed_organisation_edit_path(archived_edit.organisation, archived_edit)
+    expect(page).not_to have_link 'View Details', href: organisation_proposed_organisation_edit_path(archived_edit.organisation, archived_edit)
   end
 end
 

--- a/features/step_definitions/static_pages_steps.rb
+++ b/features/step_definitions/static_pages_steps.rb
@@ -14,10 +14,10 @@ Given(/^I am on the show page with the "(.*?)" permalink$/) do |permalink|
 end
 
 Given(/^I visit the pages manager$/) do
-  steps %Q{
+  steps %(
     When I am on the home page
     And I follow "About HCN"
-    And I follow "Pages"}
+    And I follow "Pages")
 end
 
 Given(/^I remove "(.*?)" from the footer$/) do |permalink|
@@ -34,7 +34,7 @@ Then(/^the "(.*?)" link is in the footer$/) do |link|
   expect(page.has_xpath? "//footer//a[@href=\"\/#{link}\"]").to be true
 end
 
-And(/^I add "(.*?)" to the footer$/) do |arg1|
+And(/^I add "(.*?)" to the footer$/) do |_arg1|
   pending # express the regexp above with the code you wish you had
 end
 

--- a/features/step_definitions/upgrade_users_steps.rb
+++ b/features/step_definitions/upgrade_users_steps.rb
@@ -1,4 +1,4 @@
-Given("superadmin already upgraded {string} user") do |email|
+Given('superadmin already upgraded {string} user') do |email|
   step %(I am signed in as a superadmin)
   step %(I visit the registered users page)
   step %(I click on "Upgrade" for the user "#{email}")

--- a/features/step_definitions/volunteer_op_steps.rb
+++ b/features/step_definitions/volunteer_op_steps.rb
@@ -2,29 +2,29 @@ regex = /^I submit a volunteer op "(.*?)", "(.*?)" on the "(.*?)" page$/
 And(regex) do |title, desc, org_name|
   org = Organisation.find_by_name(org_name)
   visit organisation_path org
-  click_link "Create a Volunteer Opportunity"
+  click_link 'Create a Volunteer Opportunity'
   expect(current_path).to eq new_organisation_volunteer_op_path org
-  fill_in 'Title', :with => title
-  fill_in 'Description', :with => desc
+  fill_in 'Title', with: title
+  fill_in 'Description', with: desc
   expect_any_instance_of(TwitterApi).to receive(:tweet).once
   click_on 'Create a Volunteer Opportunity'
 end
 
-Given /^I submit a blank volunteer op on the "(.*?)" page$/ do |org_name|
+Given(/^I submit a blank volunteer op on the "(.*?)" page$/) do |org_name|
   org = Organisation.find_by_name(org_name)
   visit organisation_path org
-  click_link "Create a Volunteer Opportunity"
+  click_link 'Create a Volunteer Opportunity'
   expect(current_path).to eq new_organisation_volunteer_op_path org
   click_on 'Create a Volunteer Opportunity'
 end
 
-When("I submit a valid volunteer opportunity") do
+When('I submit a valid volunteer opportunity') do
   org = Organisation.find_by_name('Friendly')
   visit organisation_path org
-  click_link "Create a Volunteer Opportunity"
+  click_link 'Create a Volunteer Opportunity'
   expect(current_path).to eq new_organisation_volunteer_op_path org
-  fill_in 'Title', :with => 'title'
-  fill_in 'Description', :with => 'desc'
+  fill_in 'Title', with: 'title'
+  fill_in 'Description', with: 'desc'
   click_on 'Create a Volunteer Opportunity'
 end
 
@@ -58,8 +58,8 @@ Given(/^I submit a volunteer op to Doit/) do |volunteer_ops_table|
     fill_in 'Postcode', with: volunteer_op['postcode']
     check('check_to_doit')
     select('Help Out Harrow!', from: 'Doit organisation')
-    fill_in 'Advertise start date', with: Date.current.strftime("%F")
-    fill_in 'Advertise end date', with: 10.days.from_now.strftime("%F")
+    fill_in 'Advertise start date', with: Date.current.strftime('%F')
+    fill_in 'Advertise end date', with: 10.days.from_now.strftime('%F')
     expect_any_instance_of(TwitterApi).to receive(:tweet).once
     click_on 'Create a Volunteer Opportunity'
   end
@@ -107,39 +107,43 @@ Then(/^the doit volunteer op with id "(.*?)" should not be stored$/) do |doit_id
 end
 
 Given(/^that the (.+) flag is (enabled|disabled)$/) do |feature, state|
-  if f = Feature.find_by_name(feature) then
+  f = Feature.find_by_name(feature)
+  if f
     f.update_attributes(active: (state == 'enabled'))
   else
     Feature.create!(name: feature, active: (state == 'enabled'))
   end
+  Feature.find_or_create_by(name: feature) do |f|
+    f.active = (state == 'enabled')
+  end
 end
 
-Given /^I update "(.*?)" volunteer op description to be "(.*?)"$/ do |title, description|
+Given(/^I update "(.*?)" volunteer op description to be "(.*?)"$/) do |title, description|
   vop = VolunteerOp.find_by_title title
   visit volunteer_op_path vop
   click_on 'Edit'
-  fill_in('Description', :with => description)
+  fill_in('Description', with: description)
   click_on 'Update Volunteer Opportunity'
 end
 
-Given /^I update "(.*?)" volunteer op title to be "(.*?)"$/ do |title, description|
+Given(/^I update "(.*?)" volunteer op title to be "(.*?)"$/) do |title, _description|
   vop = VolunteerOp.find_by_title title
   visit volunteer_op_path vop
   click_on 'Edit'
-  fill_in('Title', :with => title)
+  fill_in('Title', with: title)
   click_on 'Update Volunteer Opportunity'
 end
 
-Given /^I should see (\d+) markers in the map$/ do |num|
+Given(/^I should see (\d+) markers in the map$/) do |num|
   expect(page).to have_css('.vol_op', count: num)
 end
 
 Then(/^I should see a link to "(.*?)" page "(.*?)"$/) do |link, url|
-  page.should have_link(link, :href => url)
+  page.should have_link(link, href: url)
 end
 
 Then(/^I should see a tracking link to "(.*?)" page "(.*?)"$/) do |link, url|
-  page.should have_link(link, :href => "#{url}")
+  page.should have_link(link, href: "#{url}")
 end
 
 When(/^I set new volunteer opportunity location to "(.*?)", "(.*?)"$/) do |addr, pc|
@@ -179,7 +183,7 @@ Given /^wait for (\d+) seconds?$/ do |n|
 end
 
 Given(/^I fill additional fields required by Doit$/) do
-  select("Help Out Harrow!", from: 'doit_volunteer_op_doit_org_id')
+  select('Help Out Harrow!', from: 'doit_volunteer_op_doit_org_id')
   fill_in('Advertise start date', with: '2017-03-01')
   fill_in('Advertise end date', with: '2017-04-01')
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -141,7 +141,7 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 #end
 # Aruba working directory (default: Aruba creates tmp/aruba)
 Before do
-  @dirs = ["#{Rails.root.to_s}"]
+  @dirs = ["#{Rails.root}"]
 end
 
 Before('@in-production') do

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -39,16 +39,16 @@ module MapHelpers
   def stub_request_with_address(address, body = nil)
     filename = "#{address.downcase.gsub(/,/,'').gsub(/\s/, '_')}.json"
     filename = File.read "test/fixtures/#{filename}"
-    stub_request(:any, /maps\.googleapis\.com/).
-        to_return(:status => 200, :body => body || filename, :headers => {})
+    stub_request(:any, /maps\.googleapis\.com/)
+        .to_return(status: 200, body: body || filename, headers: {})
   end
 end
 
 module ProposedOrgHelpers
   def unsaved_proposed_organisation(associated_user = nil)
-    proposed_org = ProposedOrganisation.new({name: "Friendly Charity", description: "We are friendly!",
-      email: "sample@sample.org", address: "30 pinner road", donation_info: "https://www.donate.com",
-      postcode: 'HA1 4HZ', non_profit: true})
+    proposed_org = ProposedOrganisation.new(name: 'Friendly Charity', description: 'We are friendly!',
+      email: 'sample@sample.org', address: '30 pinner road', donation_info: 'https://www.donate.com',
+      postcode: 'HA1 4HZ', non_profit: true)
     proposed_org.users << associated_user if associated_user
     proposed_org
   end

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -1,6 +1,6 @@
 VCR.configure do |config|
   config.ignore_localhost = true
-  config.cassette_library_dir = "features/vcr_cassettes"
+  config.cassette_library_dir = 'features/vcr_cassettes'
   config.hook_into :webmock
   config.debug_logger = File.open('vcr.log', 'w')
   config.default_cassette_options = { record: :new_episodes }
@@ -10,5 +10,5 @@ VCR.configure do |config|
 end
 
 VCR.cucumber_tags do |t|
-  t.tag  '@vcr', :use_scenario_name => true
+  t.tag  '@vcr', use_scenario_name: true
 end

--- a/lib/boolean.rb
+++ b/lib/boolean.rb
@@ -1,14 +1,6 @@
 module Boolean
   def self.from(value)
-    [
-      '1',
-      1,
-      'y',
-      'yes',
-      't',
-      'true',
-      true
-    ].include? (value.try(:downcase) || value)
+    [ '1', 1, 'y', 'yes', 't', 'true', true ].include? (value.try(:downcase) || value)
   end
 end
 

--- a/lib/custom_errors.rb
+++ b/lib/custom_errors.rb
@@ -20,10 +20,10 @@ module CustomErrors
     error.backtrace.each_with_index { |line, index| Rails.logger.error line; break if index >= 5 }
 
     case status
-      when 404
+    when 404
         render template: 'pages/404', status: 404
 
-      when 500
+    when 500
         render template: 'pages/500', status: 500
 
       else

--- a/lib/proposes_edits.rb
+++ b/lib/proposes_edits.rb
@@ -11,7 +11,7 @@ module ProposesEdits
 
   def accept params
     instance_to_edit.update(params)
-    update!(:accepted => true, :archived => true)
+    update!(accepted: true, archived: true)
   end
 
   def non_published_generally_editable_fields

--- a/lib/string.rb
+++ b/lib/string.rb
@@ -1,6 +1,6 @@
 class String
   def humanized_all_first_capitals
-    self.humanize.split(' ').map{|w| w.capitalize}.join(' ')
+    self.humanize.split(' ').map(&:capitalize).join(' ')
   end
   
   def downcase_words
@@ -26,7 +26,7 @@ class String
     "#{slug_words.join('-')}-org"
   end
   
-  NOT_WANTED = %w(the of for and in to)
+  NOT_WANTED = %w[the of for and in to]
   
   private
   

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -1,13 +1,13 @@
 begin
   namespace :db do
     desc 'Import categories from named CSV file '
-    task :categories => :environment do
+    task categories: :environment do
       Logger.new(STDOUT).info 'Start Categories seed'
       Category.seed 'db/charity_classifications.csv'
       Logger.new(STDOUT).info 'Categories seed finished'
     end
     desc 'Import category mapping from named CSV file'
-    task :cat_org_import => :environment do
+    task cat_org_import: :environment do
       Logger.new(STDOUT).info 'Start Category Organisation mapping seed'
       Organisation.import_category_mappings 'db/data.csv' , 1006
       Logger.new(STDOUT).info 'Mapping Category Organisation finished'

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -14,20 +14,20 @@ begin
   require 'cucumber/rake/task'
 
   namespace :cucumber do
-    Cucumber::Rake::Task.new({:ok => 'db:test:prepare'}, 'Run features that should pass') do |t|
+    Cucumber::Rake::Task.new({ok: 'db:test:prepare'}, 'Run features that should pass') do |t|
       t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'default'
     end
 
-    Cucumber::Rake::Task.new({:wip => 'db:test:prepare'}, 'Run features that are being worked on') do |t|
+    Cucumber::Rake::Task.new({wip: 'db:test:prepare'}, 'Run features that are being worked on') do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'wip'
     end
 
     desc 'Run all features'
-    task :all => [:ok, :wip]
+    task all: [:ok, :wip]
 
     desc 'Run all features, record any failures'
     Cucumber::Rake::Task.new(:first_try) do |t|
@@ -45,16 +45,16 @@ begin
 
     task :statsetup do
       require 'rails/code_statistics'
-      ::STATS_DIRECTORIES << %w(Cucumber\ features features) if File.exist?('features')
-      ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?('features')
+      ::STATS_DIRECTORIES << %w[Cucumber\ features features] if File.exist?('features')
+      ::CodeStatistics::TEST_TYPES << 'Cucumber features' if File.exist?('features')
     end
   end
   desc 'Alias for cucumber:ok'
-  task :cucumber => 'cucumber:ok'
+  task cucumber: 'cucumber:ok'
 
-  task :default => :cucumber
+  task default: :cucumber
 
-  task :features => :cucumber do
+  task features: :cucumber do
     STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"
   end
 
@@ -62,7 +62,7 @@ begin
   task 'db:test:prepare' do
   end
 
-  task :stats => 'cucumber:statsetup'
+  task stats: 'cucumber:statsetup'
 rescue LoadError
   desc 'cucumber rake task not available (cucumber not installed)'
   task :cucumber do

--- a/lib/tasks/custom_setup.rake
+++ b/lib/tasks/custom_setup.rake
@@ -2,7 +2,7 @@ Rake::Task['db:setup'].clear
 begin
   namespace :db do
     desc 'Setup project data'
-    task :setup => :environment do
+    task setup: :environment do
 
       Rake::Task['db:categories'].invoke
       Rake::Task['db:seed'].invoke

--- a/lib/tasks/email_template.rake
+++ b/lib/tasks/email_template.rake
@@ -6,7 +6,7 @@
 begin
   namespace :db do
     desc 'Create email template for invitation instructions'
-    task :email_template => :environment do
+    task email_template: :environment do
       Logger.new(STDOUT).info 'Start email template generation'
 
       f = File.read('./db/invitation_instructions.txt').split(/\n---\n/)

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -4,10 +4,10 @@ begin
   namespace :db do
     namespace :import do
       desc 'Import email addresses from a named CSV file'
-      task :emails, [:file] => :environment do |t, args|
+      task :emails, [:file] => :environment do |_t, args|
         Logger.new(STDOUT).info 'Start emails import'
         # pass variables like so bundle exec rake db:import:emails[db/emails.csv]
-        require File.expand_path("../../config/environment", File.dirname(__FILE__))
+        require File.expand_path('../../config/environment', File.dirname(__FILE__))
         #this is needed because rake tasks load classes lazily; from the command line, the task will
         #otherwise fail because it takes the below intended monkeypatch as first definition
         Rails.logger.tagged('IMPORT EMAILS') do

--- a/lib/tasks/fix_invites.rake
+++ b/lib/tasks/fix_invites.rake
@@ -3,16 +3,16 @@
 begin
   namespace :db do
    desc 'Link pending invited users to organisations'
-   task :fix_invites => :environment do
+   task fix_invites: :environment do
       current_invites = User.invited_not_accepted
       nil_org_users = current_invites.select {|user| user.organisation_id.nil?}
       nil_org_users.each do |user|
-        query_result = Organisation.where("UPPER(email) LIKE ? ", "%#{user.email.upcase}%")
+        query_result = Organisation.where('UPPER(email) LIKE ? ', "%#{user.email.upcase}%")
         org = query_result.first
         puts "Wrong number of orgs: #{org.email}" if query_result.length != 1
         user.organisation_id = org.id
         user.save!
       end
-    end
+   end
   end
 end

--- a/lib/tasks/generate_friendly_id.rake
+++ b/lib/tasks/generate_friendly_id.rake
@@ -1,7 +1,7 @@
 begin
   namespace :db do
     desc 'Generate friendly id for Organisations records'
-    task :friendly_id => :environment do
+    task friendly_id: :environment do
       Logger.new(STDOUT).info 'Start friendly_id generation'
       Organisation.find_each do |org|
         WithoutTimestamps.run do

--- a/lib/tasks/import_doit.rake
+++ b/lib/tasks/import_doit.rake
@@ -1,7 +1,7 @@
 begin
   namespace :db do
     desc 'Import volunteer opportunities from DoIt (http://do-it.org)'
-    task :import_doit => :environment do
+    task import_doit: :environment do
       ImportDoItVolunteerOpportunities.with(3.0)
     end
   end

--- a/lib/tasks/pages.rake
+++ b/lib/tasks/pages.rake
@@ -1,8 +1,8 @@
 namespace :db do
   desc 'Creates page records'
-  task :pages => :environment do
+  task pages: :environment do
     unless Page.find_by_permalink('about')
-      Page.create!({
+      Page.create!(
                      name: 'About Us',
                      permalink: 'about',
                      content:
@@ -18,10 +18,10 @@ We are a not-for-profit workers co-operative who support people and not-for-prof
 Find out [here (VAH in a nutshell)](http://www.voluntaryactionharrow.org.uk/vah-in-a-nutshell)
 ### What is a Workers Co-operative?
 A workers co-operative is a business owned and democratically controlled by their employee members using co-operative principles. They are an attractive and increasingly relevant alternative to traditional investor owned models of enterprise.[ (Click here for more details)](http://www.uk.coop/sites/default/files/worker_co-operative_code_2nd_edition.pdf)'
-                 })
+                   )
     end
     unless Page.find_by_permalink('contact')
-      Page.create!({
+      Page.create!(
                      name: 'Contact Info',
                      permalink: 'contact',
                      content:
@@ -30,25 +30,25 @@ A workers co-operative is a business owned and democratically controlled by thei
 * **Phone Us:** 020 8861 5894
 * **Write to Us:** The Lodge, 64 Pinner Road, Harrow, Middlesex, HA1 4HZ
 * **Find Us:** On [ Social Media (Click Here)](http://www.voluntaryactionharrow.org.uk/social-circles/)'
-                 })
+                   )
     end
     unless Page.find_by_permalink('disclaimer')
-      Page.create!({
+      Page.create!(
                      name: 'Disclaimer',
                      permalink: 'disclaimer',
                      content:
 '# Disclaimer
 #### Whilst Voluntary Action Harrow has made effort to ensure the information here is accurate and up to date we are reliant on the information provided by the different organisations. No guarantees for the accuracy of the information is made.'
-                 })
+                   )
     end
     unless Page.find_by_permalink('404')
-      Page.create!({
+      Page.create!(
                      name: 'Custom 404',
                      permalink: '404',
                      content:
                          "# 404
 #### We're sorry, but we couldn't find the page you requested!"
-                 })
+                   )
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-describe ApplicationController, :type => :controller, :helpers => :controllers do
+describe ApplicationController, type: :controller, helpers: :controllers do
   render_views
 
   it '#request_controller_is(white_listed)' do
-    allow(controller).to receive_messages white_listed: %w(a b c)
+    allow(controller).to receive_messages white_listed: %w[a b c]
     allow(request).to receive_messages params: {'controller' => 'a'}
     expect(controller.request_controller_is(controller.white_listed)).to be true
 
@@ -21,18 +21,18 @@ describe ApplicationController, :type => :controller, :helpers => :controllers d
   end
 
   it '#store_location stores URLs only when conditions permit' do
-    allow(request).to receive_messages :path => 'this/is/a/path'
+    allow(request).to receive_messages path: 'this/is/a/path'
 
-    allow(controller).to receive_messages :request_controller_is => false
-    allow(controller).to receive_messages :request_verb_is_get? => false
+    allow(controller).to receive_messages request_controller_is: false
+    allow(controller).to receive_messages request_verb_is_get?: false
     controller.store_location
     expect(session[:previous_url]).to be_nil
 
-    allow(controller).to receive_messages :request_controller_is => true
+    allow(controller).to receive_messages request_controller_is: true
     controller.store_location
     expect(session[:previous_url]).to be_nil
 
-    allow(controller).to receive_messages :request_verb_is_get? => true
+    allow(controller).to receive_messages request_verb_is_get?: true
     controller.store_location
     expect(session[:previous_url]).to eq request.fullpath
   end
@@ -41,21 +41,21 @@ describe ApplicationController, :type => :controller, :helpers => :controllers d
     let(:user) { make_current_user_nonsuperadmin }
     context 'user not associated with any org' do
       it 'should redirect to root' do
-        allow(user).to receive_messages :organisation => nil, :pending_organisation_id => nil
+        allow(user).to receive_messages organisation: nil, pending_organisation_id: nil
         expect(controller.after_sign_in_path_for(user)).to eq '/'
       end
     end
 
     context 'user is org owner no previous url' do
       it 'should redirect to root' do
-        allow(user).to receive_messages :organisation => mock_model(Organisation, id: 1, has_been_updated_recently?: false)
+        allow(user).to receive_messages organisation: mock_model(Organisation, id: 1, has_been_updated_recently?: false)
         expect(controller.after_sign_in_path_for(user)).to eq '/organisations/1'
       end
     end
 
     context 'user is org owner with previous url' do
       it 'should redirect to root' do
-        allow(user).to receive_messages :organisation => mock_model(Organisation, id: 1, has_been_updated_recently?: false)
+        allow(user).to receive_messages organisation: mock_model(Organisation, id: 1, has_been_updated_recently?: false)
         session[:previous_url] = 'i/was/here'
         expect(controller.after_sign_in_path_for(user)).to eq '/organisations/1'
       end
@@ -64,11 +64,11 @@ describe ApplicationController, :type => :controller, :helpers => :controllers d
 
   it '#after_accept_path_for' do
     user = make_current_user_nonsuperadmin
-    allow(user).to receive_messages :organisation => nil
+    allow(user).to receive_messages organisation: nil
 
     expect(controller.after_accept_path_for(user)).to eq '/'
 
-    allow(user).to receive_messages :organisation => '1'
+    allow(user).to receive_messages organisation: '1'
     expect(controller.after_accept_path_for(user)).to eq '/organisations/1'
   end
 
@@ -79,7 +79,7 @@ describe ApplicationController, :type => :controller, :helpers => :controllers d
     it 'cookie is set and redirected to referer' do
       request.headers.merge! referer:'/hello'
       get :allow_cookie_policy
-      expect(response).to redirect_to "/hello"
+      expect(response).to redirect_to '/hello'
     end
 
     it 'redirects to root if request referer is nil' do
@@ -179,7 +179,7 @@ end
 
 # all child controllers should implement the ApplicationController's
 # before_action
-describe OrganisationsController, :type => :controller do
+describe OrganisationsController, type: :controller do
   it 'assigns footer page links on a given request' do
     get :index
     expect(assigns(:footer_page_links)).not_to be nil

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ContributorsController, :type => :controller do
+describe ContributorsController, type: :controller do
 
   describe 'GET show' do
     before :each do
@@ -10,9 +10,9 @@ describe ContributorsController, :type => :controller do
       ]
       json_data = @contributors.to_json
 
-      stub_request(:get, /api.github.com/).
-          with(:headers => {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
-          to_return(:status => 200, :body => json_data, :headers => {})
+      stub_request(:get, /api.github.com/)
+          .with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'})
+          .to_return(status: 200, body: json_data, headers: {})
     end
 
     it 'assigns the contributors appropriately' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe EventsController, type: :controller, helpers: :requests do
     {
         title: 'comic-con',
         description: 'superheroes',
-        start_date: Date.today,
-        end_date: Date.today + 3.hours,
+        start_date: Time.zone.today,
+        end_date: Time.zone.today + 3.hours,
         organisation_id: organisation.id,
         address: '4 pinner road'
     }
@@ -17,8 +17,8 @@ RSpec.describe EventsController, type: :controller, helpers: :requests do
     {
         title: 'comic-con',
         description: 'superheroes',
-        start_date: Date.today,
-        end_date: Date.today + 3.hours
+        start_date: Time.zone.today,
+        end_date: Time.zone.today + 3.hours
     }
   end
 
@@ -69,7 +69,7 @@ RSpec.describe EventsController, type: :controller, helpers: :requests do
         post :create, params: {event: valid_attributes}
         expect(response).to redirect_to(Event.last)
       end
-      
+
       it 'assigns the address in params to address attribute' do
         post :create, params: { event: valid_attributes }
         expect(assigns(:event).attributes.symbolize_keys[:address]).to eq('4 pinner road')

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EventsController, type: :controller, helpers: :requests do
         start_date: Date.today,
         end_date: Date.today + 3.hours,
         organisation_id: organisation.id,
-        address: "4 pinner road"
+        address: '4 pinner road'
     }
   end
 
@@ -72,7 +72,7 @@ RSpec.describe EventsController, type: :controller, helpers: :requests do
       
       it 'assigns the address in params to address attribute' do
         post :create, params: { event: valid_attributes }
-        expect(assigns(:event).attributes.symbolize_keys[:address]).to eq("4 pinner road")
+        expect(assigns(:event).attributes.symbolize_keys[:address]).to eq('4 pinner road')
       end
     end
 

--- a/spec/controllers/organisation_reports_controller_spec.rb
+++ b/spec/controllers/organisation_reports_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OrganisationReportsController, :type => :controller do
+describe OrganisationReportsController, type: :controller do
   let(:org) { double('Organisation') }
   let(:user) { double 'User' }
   let(:session) { mock_model User, superadmin?: true, decrement_invitation_limit!: nil }

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OrganisationsController, :type => :controller do
+describe OrganisationsController, type: :controller do
   let(:category_html_options) { [['cat1', 1], ['cat2', 2]] }
 
   # http://stackoverflow.com/questions/10442159/rspec-as-null-object
@@ -73,7 +73,7 @@ describe OrganisationsController, :type => :controller do
 
       it 'handles lack of query term gracefully' do
         expect(Organisation).to receive(:search_by_keyword).with('').and_return(result)
-        get :search, params: category_params.merge({q: ''})
+        get :search, params: category_params.merge(q: '')
         expect(assigns(:parsed_params).query_term).to eq('')
       end
 
@@ -88,7 +88,7 @@ describe OrganisationsController, :type => :controller do
         expect(response).to render_template 'layouts/two_columns_with_map'
         expect(assigns(:organisations)).to eq([double_organisation])
         expect(assigns(:markers)).to eq(markers)
-        expect(assigns(:cat_name_ids)).to eq({what: [], how: [], who: []})
+        expect(assigns(:cat_name_ids)).to eq(what: [], how: [], who: [])
       end
     end
 
@@ -250,7 +250,7 @@ describe OrganisationsController, :type => :controller do
     context 'while signed in' do
       before(:each) do
         user = double('User')
-        allow(request.env['warden']).to receive_messages :authenticate! => user
+        allow(request.env['warden']).to receive_messages authenticate!: user
         allow(controller).to receive(:current_user).and_return(user)
         allow(Organisation).to receive(:new) { double_organisation }
       end
@@ -281,7 +281,7 @@ describe OrganisationsController, :type => :controller do
       before(:each) do
         user = double('User')
         allow(user).to receive(:can_edit?) { true }
-        allow(request.env['warden']).to receive_messages :authenticate! => user
+        allow(request.env['warden']).to receive_messages authenticate!: user
         allow(controller).to receive(:current_user).and_return(user)
       end
 
@@ -295,7 +295,7 @@ describe OrganisationsController, :type => :controller do
       before(:each) do
         user = double('User')
         allow(user).to receive(:can_edit?) { false }
-        allow(request.env['warden']).to receive_messages :authenticate! => user
+        allow(request.env['warden']).to receive_messages authenticate!: user
         allow(controller).to receive(:current_user).and_return(user)
       end
 
@@ -307,7 +307,7 @@ describe OrganisationsController, :type => :controller do
     #TODO: way to dry out these redirect specs?
     context 'while not signed in' do
       it 'redirects to sign-in' do
-        get :edit, params: {:id => '37'}
+        get :edit, params: {id: '37'}
         expect(response).to redirect_to new_user_session_path
       end
     end
@@ -353,8 +353,8 @@ describe OrganisationsController, :type => :controller do
 
     context 'while not signed in' do
       it 'redirects to sign-in' do
-        allow(Organisation).to receive(:new).with({'these' => 'params'}) { double_organisation(:save => true) }
-        post :create, params: {:organisation => {'these' => 'params'}}
+        allow(Organisation).to receive(:new).with('these' => 'params') { double_organisation(save: true) }
+        post :create, params: {organisation: {'these' => 'params'}}
         expect(response).to redirect_to new_user_session_path
       end
     end
@@ -367,20 +367,20 @@ describe OrganisationsController, :type => :controller do
       describe 'with valid params' do
         it 'refuses to create a new organisation' do
           # stubbing out Organisation to prevent new method from calling Gmaps APIs
-          allow(Organisation).to receive(:new).with({'these' => 'params'}) { double_organisation(:save => true) }
+          allow(Organisation).to receive(:new).with('these' => 'params') { double_organisation(save: true) }
           expect(Organisation).not_to receive :new
-          post :create, params: {:organisation => {'these' => 'params'}}
+          post :create, params: {organisation: {'these' => 'params'}}
         end
 
         it 'redirects to the organisations index' do
-          allow(Organisation).to receive(:new).with({'these' => 'params'}) { double_organisation(:save => true) }
-          post :create, params: {:organisation => {'these' => 'params'}}
+          allow(Organisation).to receive(:new).with('these' => 'params') { double_organisation(save: true) }
+          post :create, params: {organisation: {'these' => 'params'}}
           expect(response).to redirect_to organisations_path
         end
 
         it 'assigns a flash refusal' do
-          allow(Organisation).to receive(:new).with({'these' => 'params'}) { double_organisation(:save => true) }
-          post :create, params: {:organisation => {'these' => 'params'}}
+          allow(Organisation).to receive(:new).with('these' => 'params') { double_organisation(save: true) }
+          post :create, params: {organisation: {'these' => 'params'}}
           expect(flash[:notice]).to eq('You don\'t have permission')
         end
       end
@@ -395,7 +395,7 @@ describe OrganisationsController, :type => :controller do
       before(:each) do
         user = double('User')
         allow(user).to receive(:can_edit?) { true }
-        allow(request.env['warden']).to receive_messages :authenticate! => user
+        allow(request.env['warden']).to receive_messages authenticate!: user
         allow(controller).to receive(:current_user).and_return(user)
         
       end
@@ -404,7 +404,7 @@ describe OrganisationsController, :type => :controller do
         it 'updates org for e.g. donation_info url' do
           expect(Organisation).to receive(:friendly) { all_orgs }
           expect(all_orgs).to receive(:find).with('37') { org }
-          expect(org).to receive(:update_attributes_with_superadmin).with({'donation_info' => 'http://www.friendly.com/donate', 'superadmin_email_to_add' => nil})
+          expect(org).to receive(:update_attributes_with_superadmin).with('donation_info' => 'http://www.friendly.com/donate', 'superadmin_email_to_add' => nil)
           put :update, params: {id: '37', organisation: {'donation_info' => 'http://www.friendly.com/donate'}}
         end
 
@@ -446,7 +446,7 @@ describe OrganisationsController, :type => :controller do
       before(:each) do
         user = double('User')
         allow(user).to receive(:can_edit?) { false }
-        allow(request.env['warden']).to receive_messages :authenticate! => user
+        allow(request.env['warden']).to receive_messages authenticate!: user
         allow(controller).to receive(:current_user).and_return(user)
       end
 
@@ -516,11 +516,11 @@ describe OrganisationsController, :type => :controller do
   end
   describe 'get_user_opts' do
     let!(:org) { FactoryBot.create(:organisation)}
-    subject { 
+    subject do 
       user = create :user
       allow(controller).to receive(:current_user).and_return(user)
       user_opts = controller.send(:get_user_options, org)
-    }
+    end
     it { is_expected.to be_a_kind_of Hash }
     it { is_expected.to include(pending_org_admin: false) }
     it { is_expected.to include(editable: false) }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PagesController, :type => :controller do
+describe PagesController, type: :controller do
   let(:page) { mock_model Page, id: '2' }
 
   before { allow(controller).to receive(:superadmin?) { true } }
@@ -17,7 +17,7 @@ describe PagesController, :type => :controller do
       expect(response).to render_template 'layouts/full_width'
     end
 
-    it "assigns the pages in alphabetical order by default" do
+    it 'assigns the pages in alphabetical order by default' do
       pages = double Array
       expect(Page).to receive(:order).with('name ASC').and_return pages
       get :index, {}
@@ -26,11 +26,12 @@ describe PagesController, :type => :controller do
   end
 
   describe 'GET show' do
-    let(:about_page) { double :page,
+    let(:about_page) do 
+      double :page,
                               name: 'About Us',
                               permalink: 'about',
                               content: 'blah blah'
-    }
+    end
     let(:user) { double :user }
 
     before(:each) do
@@ -252,8 +253,8 @@ describe PagesController, :type => :controller do
       expect(response.status).to eq 302
     end
   end
-  describe ".permit" do
-    it "returns the cleaned params" do
+  describe '.permit' do
+    it 'returns the cleaned params' do
       pages_params = { page: {content: 'stuff', name: 'this', permalink: 'here', link_visible: false}}
       params = ActionController::Parameters.new.merge(pages_params)
       permitted_params = PagesController::PageParams.build(params)

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -32,7 +32,7 @@ describe Devise::PasswordsController, type: :controller do
         expect(assigns(:user).errors.full_messages).to include 'Email not found in our database. Sorry!'
       end
     end
-   end
+  end
 
    describe 'PUT update' do
      before :each do

--- a/spec/controllers/proposed_organisations_controller_spec.rb
+++ b/spec/controllers/proposed_organisations_controller_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-describe ProposedOrganisationsController, :type => :controller do
+describe ProposedOrganisationsController, type: :controller do
   let!(:proposed_org) { FactoryBot.create :proposed_organisation }
   let!(:orphan_org) { FactoryBot.create :orphan_proposed_organisation }
   let(:user) { FactoryBot.create :user }
   
   context 'superadmin paths' do
-    before(:each) { 
+    before(:each) do 
       allow(controller).to receive(:require_superadmin).and_return(true)
-    }
+    end
     
     context 'PATCH #update' do
       context 'when email is present and organisation is accepted' do
@@ -83,9 +83,9 @@ describe ProposedOrganisationsController, :type => :controller do
   end
   
   context 'other users\' paths' do
-    before(:each) { 
+    before(:each) do 
       allow_any_instance_of(User).to receive(:try).with(:superadmin?).and_return(false)
-    }
+    end
     
     context 'PATCH #update' do
       shared_examples 'permission is denied' do

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -35,8 +35,8 @@ describe RegistrationsController, type: :controller do
   describe 'POST create that fails' do
      before :each do
       request.env['devise.mapping'] = Devise.mappings[:user]
-      FactoryBot.create :user, {:email => 'example@example.com', :password => 'pppppppp'}
-    end
+      FactoryBot.create :user, email: 'example@example.com', password: 'pppppppp'
+     end
     it 'does not email upon failure to register' do
       post :create, params: {
           'user' => {

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -9,7 +9,7 @@ describe SessionsController, type: :controller do
     it 'redirects to home page after superadmin logs-in' do
       FactoryBot.build(
           :user, email: 'example@example.com', password: 'pppppppp', superadmin: true
-      ).save!
+        ).save!
       post :create, params: {
           'user' => {
               'email' => 'example@example.com',
@@ -42,8 +42,8 @@ describe SessionsController, type: :controller do
     it 'redirects to charity page after non-superadmin associated with org' do
       usr = FactoryBot.build(
           :user_stubbed_organisation, email: 'example@example.com', password: 'pppppppp'
-      )
-      allow(controller).to receive_messages :session => {previous_url: '/'}
+        )
+      allow(controller).to receive_messages session: {previous_url: '/'}
       post :create, params: {
           'user' => {
               'email' => 'example@example.com',

--- a/spec/controllers/user_reports_controller_spec.rb
+++ b/spec/controllers/user_reports_controller_spec.rb
@@ -40,16 +40,16 @@ describe UserReportsController, type: :controller do
 
     it 'destroys the user' do
       make_current_user_superadmin
-      expect{
+      expect do
         delete :destroy, params: {id: user.id}
-      }.to change(User, :count).by -1
+      end.to change(User, :count).by(-1)
     end
 
     it 'unless that user is the current_user' do
       make_current_user_superadmin(user)
-      expect{
+      expect do
         delete :destroy, params: {id: user.id}
-      }.not_to change(User, :count)
+      end.not_to change(User, :count)
     end
   end
 
@@ -117,7 +117,7 @@ describe UserReportsController, type: :controller do
     let(:organisation) do
       double :organisation, {
           id: '-1',
-          name: 'sample org',
+          name: 'sample org'
       }
     end
 
@@ -155,10 +155,10 @@ describe UserReportsController, type: :controller do
       expect(User).to receive(:invited_not_accepted) { [user] }
       get :invited
       expect(assigns(:invitations)).to eq([{
-                                               :id => '-1',
-                                               :name => 'sample org',
-                                               :email => 'user@email.org',
-                                               :date => 'date-time-thingy'
+                                               id: '-1',
+                                               name: 'sample org',
+                                               email: 'user@email.org',
+                                               date: 'date-time-thingy'
                                            }])
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-describe UsersController, :type => :controller do
-  describe ".permit" do
-    it "returns the cleaned params" do
-      user_params = {id: 5, email: "a@a.com", password: "blahblah", password_confirmation: "blahblah", 
+describe UsersController, type: :controller do
+  describe '.permit' do
+    it 'returns the cleaned params' do
+      user_params = {id: 5, email: 'a@a.com', password: 'blahblah', password_confirmation: 'blahblah', 
        remember_me: true, pending_organisation_id: 5, superadmin: true}
       params = ActionController::Parameters.new.merge(user_params)
       permitted_params = UsersController::UserParams.build(params)
-      expect(permitted_params).to eq({id: 5, email: "a@a.com", password: "blahblah", password_confirmation: "blahblah", 
+      expect(permitted_params).to eq({id: 5, email: 'a@a.com', password: 'blahblah', password_confirmation: 'blahblah', 
        remember_me: true, pending_organisation_id: 5}.with_indifferent_access)
     end
   end

--- a/spec/controllers/volunteer_ops_controller_spec.rb
+++ b/spec/controllers/volunteer_ops_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe VolunteerOpsController, type: :controller, helpers: :requests do
       @markers = BuildMarkersWithInfoWindow.with(
           VolunteerOp.build_by_coordinates,
           VolunteerOpsController.new
-      )
+        )
       get :index, params: {}
       expect(response).to be_success
       expect(assigns(:markers)).to eq(@markers)
@@ -121,7 +121,7 @@ RSpec.describe VolunteerOpsController, type: :controller, helpers: :requests do
       @markers = BuildMarkersWithInfoWindow.with(
           VolunteerOp.build_by_coordinates,
           VolunteerOpsController.new
-      )
+        )
       get :embedded_map, params: {}
       expect(response).to be_success
       expect(assigns(:markers)).to eq(@markers)

--- a/spec/helpers/user_reports_helper_spec.rb
+++ b/spec/helpers/user_reports_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe UserReportsHelper, :type => :helper do
+describe UserReportsHelper, type: :helper do
   describe '#time_ago_in_words_with_nils' do
     it 'should handle nils' do
       expect(time_ago_in_words_with_nils(nil)).to eq 'never'

--- a/spec/helpers/volunteer_ops_helper_spec.rb
+++ b/spec/helpers/volunteer_ops_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe VolunteerOpsHelper, :type => :helper do
+describe VolunteerOpsHelper, type: :helper do
   describe '#button_text' do
     let(:op) { double :volunteer_op }
 

--- a/spec/jobs/post_to_doit_job_spec.rb
+++ b/spec/jobs/post_to_doit_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PostToDoitJob, type: :job do
                                 },
                                 Doit::PostToDoit,
                                 trace_double
-                                 )
+                              )
 
       expect(Doit::PostToDoit).to have_received(:call)
       expect(trace_double).to have_received(:add_entry)

--- a/spec/libs/string_utility_spec.rb
+++ b/spec/libs/string_utility_spec.rb
@@ -7,20 +7,20 @@ end
 RSpec.describe StringUtility do
   describe '.smart_truncate' do
     it 'should return empty string when truncating empty string' do
-      expect(Parent.new.smart_truncate("")).to eq("")
+      expect(Parent.new.smart_truncate('')).to eq('')
     end
 
     it 'should return empty string when truncating nil' do
-      expect(Parent.new.smart_truncate(nil)).to eq("")
+      expect(Parent.new.smart_truncate(nil)).to eq('')
     end
 
     it 'should return a the same string when the string is short' do
-      expect(Parent.new.smart_truncate("test")).to eq("test")
+      expect(Parent.new.smart_truncate('test')).to eq('test')
     end
 
     it 'should return a truncated string when the string is long' do
-      long_string = "TO PROVIDE SAFE AND SATISFYING PLAY FOR PRE-SCHOOL CHILDREN AND TO ENCOURAGE PARENTS TO PARTICIPATE FULLY. THE PRE-SCHOOL SHALL BE OPEN TO ALL WITHOUT DISCRIMINATION."
-      expect(Parent.new.smart_truncate(long_string)).to eq "TO PROVIDE SAFE AND SATISFYING PLAY FOR PRE-SCHOOL CHILDREN AND TO ENCOURAGE PARENTS TO PARTICIPATE FULLY. THE PRE-SCHOOL SHALL BE OPEN TO ALL WITHOUT ..."
+      long_string = 'TO PROVIDE SAFE AND SATISFYING PLAY FOR PRE-SCHOOL CHILDREN AND TO ENCOURAGE PARENTS TO PARTICIPATE FULLY. THE PRE-SCHOOL SHALL BE OPEN TO ALL WITHOUT DISCRIMINATION.'
+      expect(Parent.new.smart_truncate(long_string)).to eq 'TO PROVIDE SAFE AND SATISFYING PLAY FOR PRE-SCHOOL CHILDREN AND TO ENCOURAGE PARENTS TO PARTICIPATE FULLY. THE PRE-SCHOOL SHALL BE OPEN TO ALL WITHOUT ...'
     end
   end
 end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-describe AdminMailer, :type => :mailer do
-  context "new user sign up notification" do
+describe AdminMailer, type: :mailer do
+  context 'new user sign up notification' do
     subject { AdminMailer.new_user_waiting_for_approval('friendly', 'superadmin@superadmin.org') }
     it { expect{subject.deliver_now}.to change{ActionMailer::Base.deliveries.length}.by(1) }
     it { expect(subject.subject).to eq "There is a user waiting for Admin approval to 'friendly'." }
@@ -11,10 +11,10 @@ describe AdminMailer, :type => :mailer do
     it { expect(subject.cc).to eq ['technical@harrowcn.org.uk'] }
   end
 
-  context "new user sign up notification" do
+  context 'new user sign up notification' do
     subject do
       AdminMailer.new_user_sign_up(
-        "user@charity.org", ["superadmin@harrowcn.org.uk", "superadmin2@harrowcn.org.uk"]
+        'user@charity.org', ['superadmin@harrowcn.org.uk', 'superadmin2@harrowcn.org.uk']
       )
     end
     it { expect{subject.deliver_now}.to change{ActionMailer::Base.deliveries.length}.by(1) }
@@ -24,18 +24,18 @@ describe AdminMailer, :type => :mailer do
     it { expect(subject.cc).to eq ['technical@harrowcn.org.uk'] }
   end
 
-  context "new proposed org notification" do
-    subject { AdminMailer.new_org_waiting_for_approval(double("Organisation", name: 'friendly'), 'superadmin@superadmin.org') }
+  context 'new proposed org notification' do
+    subject { AdminMailer.new_org_waiting_for_approval(double('Organisation', name: 'friendly'), 'superadmin@superadmin.org') }
     it { expect{subject.deliver_now}.to change{ActionMailer::Base.deliveries.length}.by(1) }
-    it { expect(subject.subject).to eq "A new organisation has been proposed for inclusion in Harrow Community Network" }
+    it { expect(subject.subject).to eq 'A new organisation has been proposed for inclusion in Harrow Community Network' }
     it { expect(subject.to).to eq ['superadmin@superadmin.org'] }
     it { expect(subject.from).to eq ['support@harrowcn.org.uk'] }
     it { expect(subject.reply_to).to eq ['support@harrowcn.org.uk'] }
     it { expect(subject.cc).to eq ['technical@harrowcn.org.uk'] }
   end
 
-  context "proposed org edit notification" do
-    subject { AdminMailer.edit_org_waiting_for_approval(double("Organisation", name: 'friendly'), 'superadmin@superadmin.org') }
+  context 'proposed org edit notification' do
+    subject { AdminMailer.edit_org_waiting_for_approval(double('Organisation', name: 'friendly'), 'superadmin@superadmin.org') }
     it { expect{subject.deliver_now}.to change{ActionMailer::Base.deliveries.length}.by(1) }
     it { expect(subject.subject).to eq "An edit to 'friendly' is awaiting Admin approval." }
     it { expect(subject.to).to eq ['superadmin@superadmin.org'] }

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-describe CustomDeviseMailer, :type => :mailer do
-  context "proposed org approved" do
+describe CustomDeviseMailer, type: :mailer do
+  context 'proposed org approved' do
     let(:proposed_org){FactoryBot.create(:orphan_proposed_organisation)}
-    let(:email){"unregistered@email.com"}
+    let(:email){'unregistered@email.com'}
     let(:user){FactoryBot.create(:user)}
     subject { CustomDeviseMailer.proposed_org_approved(proposed_org,email,user) }
 
-    it { expect(subject.subject).to eq "Your organisation has been approved for inclusion in the Harrow Community Network!"}
+    it { expect(subject.subject).to eq 'Your organisation has been approved for inclusion in the Harrow Community Network!'}
     it { expect(subject.to).to eq [email] }
     it { expect(subject.from).to eq ['support@harrowcn.org.uk'] }
     it { expect(subject.reply_to).to eq ['support@harrowcn.org.uk'] }

--- a/spec/mailers/org_admin_mailer_spec.rb
+++ b/spec/mailers/org_admin_mailer_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-describe OrgAdminMailer, :type => :mailer do
-  let(:org){double("Organisation", name: 'friendly')}
-  context "new org admin notification" do
+describe OrgAdminMailer, type: :mailer do
+  let(:org){double('Organisation', name: 'friendly')}
+  context 'new org admin notification' do
     subject { OrgAdminMailer.new_org_admin( org , 'orgadmin@friendly.org')}
     it { expect{subject.deliver_now}.to change{ActionMailer::Base.deliveries.length}.by(1) }
-    it { expect(subject.subject).to eq "You have been made an organisation administrator on the Harrow Community Network" }
+    it { expect(subject.subject).to eq 'You have been made an organisation administrator on the Harrow Community Network' }
     it { expect(subject.to).to eq ['orgadmin@friendly.org'] }
     it { expect(subject.from).to eq ['support@harrowcn.org.uk'] }
     it { expect(subject.reply_to).to eq ['support@harrowcn.org.uk'] }
     it { expect(subject.cc).to eq ['technical@harrowcn.org.uk'] }
   end
 
-  context "#notify_proposed_org_accepted" do
-    subject{OrgAdminMailer.notify_proposed_org_accepted(org,"orgadmin@friendly.org")}
+  context '#notify_proposed_org_accepted' do
+    subject{OrgAdminMailer.notify_proposed_org_accepted(org,'orgadmin@friendly.org')}
     it{expect{subject.deliver_now}.to change{ActionMailer::Base.deliveries.length}.by(1)}
-    it { expect(subject.subject).to eq "Your Organisation has been accepted for inclusion on the Harrow Community Network" }
+    it { expect(subject.subject).to eq 'Your Organisation has been accepted for inclusion on the Harrow Community Network' }
     it { expect(subject.to).to eq ['orgadmin@friendly.org'] }
     it { expect(subject.from).to eq ['support@harrowcn.org.uk'] }
     it { expect(subject.reply_to).to eq ['support@harrowcn.org.uk'] }

--- a/spec/migrations/add_link_visible_flag_to_page_spec.rb
+++ b/spec/migrations/add_link_visible_flag_to_page_spec.rb
@@ -6,8 +6,8 @@ require 'rails_helper'
 # the alternative approach would be to
 
 migration_file_name = 
-  Dir[Rails.root.
-      join('db/migrate/*_add_link_visible_flag_to_page.rb')].first
+  Dir[Rails.root
+      .join('db/migrate/*_add_link_visible_flag_to_page.rb')].first
 require migration_file_name
 
 ActiveRecord::Migration.verbose = false
@@ -18,7 +18,7 @@ describe AddLinkVisibleFlagToPage do
   # rails api that handles this. I am just going for a proof of concept here.
   def migration_has_been_run?(version)
     table_name = ActiveRecord::SchemaMigration.table_name
-    query = "SELECT version FROM %s WHERE version = '%s'" % [table_name, version]
+    query = format("SELECT version FROM %s WHERE version = '%s'", table_name, version)
     ActiveRecord::Base.connection.execute(query).any?
   end
 
@@ -26,9 +26,7 @@ describe AddLinkVisibleFlagToPage do
 
   before do
     # Hardcoded migration number
-    if migration_has_been_run?('20140325182135')
-      migration.down
-    end
+    migration.down if migration_has_been_run?('20140325182135')
   end
 
   describe '#up' do
@@ -48,8 +46,8 @@ describe AddLinkVisibleFlagToPage do
 end
 
 def seed_some_pages
-  Page.create!(:name => "About Us", :permalink => "about")
-  Page.create!(:name => "Disclaimer", :permalink => "disclaimer")
-  Page.create!(:name => "Custom 404", :permalink => "404")
+  Page.create!(name: 'About Us', permalink: 'about')
+  Page.create!(name: 'Disclaimer', permalink: 'disclaimer')
+  Page.create!(name: 'Custom 404', permalink: '404')
 end
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../app/models/address'
 
-describe Address, "#parse", :type => :model do 
+describe Address, '#parse', type: :model do 
   let(:address) { Address.new(address_to_parse) }
   subject { address.parse }
 
@@ -9,20 +9,20 @@ describe Address, "#parse", :type => :model do
       'HARROW BAPTIST CHURCH, COLLEGE ROAD, HARROW, HA1 4HZ'
     end
 
-    it { is_expected.to eql(:address => 'HARROW BAPTIST CHURCH, COLLEGE ROAD, HARROW', :postcode => 'HA1 4HZ') }
+    it { is_expected.to eql(address: 'HARROW BAPTIST CHURCH, COLLEGE ROAD, HARROW', postcode: 'HA1 4HZ') }
   end
 
   context 'must be able to handle postcode extraction when no postcode' do
     let(:address_to_parse) do 
       'HARROW BAPTIST CHURCH, COLLEGE ROAD, HARROW'
     end
-    it { is_expected.to eql(:address =>'HARROW BAPTIST CHURCH, COLLEGE ROAD, HARROW', :postcode => '') }
+    it { is_expected.to eql(address: 'HARROW BAPTIST CHURCH, COLLEGE ROAD, HARROW', postcode: '') }
   end
 
   context 'must be able to handle postcode extraction when nil address' do
     let(:address_to_parse) { nil } 
 
-    it { is_expected.to eql(:address =>'', :postcode => '') }
+    it { is_expected.to eql(address: '', postcode: '') }
   end
 end
 

--- a/spec/models/category_organisation_spec.rb
+++ b/spec/models/category_organisation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'CategoryOrganisation', :type => :model do
+describe 'CategoryOrganisation', type: :model do
   it 'should exist' do
     expect(CategoryOrganisation).not_to be_nil
   end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-describe 'Category', :type => :model do
+describe 'Category', type: :model do
 
   context 'scopes' do
-    let!(:category_array){[["education", 100], ["sports", 199], ["children", 200], ["youth", 299], ["advocacy", 300], ["umbrella", 399]]}
+    let!(:category_array){[['education', 100], ['sports', 199], ['children', 200], ['youth', 299], ['advocacy', 300], ['umbrella', 399]]}
     before do
       category_array.each do | name, charity_commission_id |
         create(:category, charity_commission_id: charity_commission_id, name: name)
       end
     end
 
-    describe "self.name_and_id_for_what_who_and_how" do
+    describe 'self.name_and_id_for_what_who_and_how' do
       subject { Category.name_and_id_for_what_who_and_how }
       it { expect(subject[:what].count).to eq(2)}
       it { expect(subject[:who].count).to eq(2) }
@@ -47,31 +47,31 @@ describe 'Category', :type => :model do
     before do
       FactoryBot.factories.clear
       FactoryBot.find_definitions
-      @category1 = FactoryBot.create(:category, name: "alligator",  charity_commission_id: 100)
-      @category4 = FactoryBot.create(:category, name: "capybara",  charity_commission_id: 101)
-      @category2 = FactoryBot.create(:category, name: "crocodile", charity_commission_id: 210)
-      @category5 = FactoryBot.create(:category, name: "guinea pig", charity_commission_id: 201)
-      @category3 = FactoryBot.create(:category, name: "iguana", charity_commission_id: 310)
-      @category6 = FactoryBot.create(:category, name: "rabbit", charity_commission_id: 304)
-      @org1 = FactoryBot.build(:organisation, :name => 'Harrow Bereavement Counselling', :description => 'Bereavement Counselling', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.harrow-bereavment.co.uk/donate')
+      @category1 = FactoryBot.create(:category, name: 'alligator',  charity_commission_id: 100)
+      @category4 = FactoryBot.create(:category, name: 'capybara',  charity_commission_id: 101)
+      @category2 = FactoryBot.create(:category, name: 'crocodile', charity_commission_id: 210)
+      @category5 = FactoryBot.create(:category, name: 'guinea pig', charity_commission_id: 201)
+      @category3 = FactoryBot.create(:category, name: 'iguana', charity_commission_id: 310)
+      @category6 = FactoryBot.create(:category, name: 'rabbit', charity_commission_id: 304)
+      @org1 = FactoryBot.build(:organisation, name: 'Harrow Bereavement Counselling', description: 'Bereavement Counselling', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.harrow-bereavment.co.uk/donate')
       allow(@org1).to receive :geocode
       @org1.save!
-      @org2 = FactoryBot.build(:organisation, :name => 'Indian Elders Associaton', :description => 'Care for the elderly', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.indian-elders.co.uk/donate')
+      @org2 = FactoryBot.build(:organisation, name: 'Indian Elders Associaton', description: 'Care for the elderly', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.indian-elders.co.uk/donate')
       allow(@org2).to receive :geocode
       @org2.categories << @category1
       @org2.categories << @category2
       @org2.save!
-      @org3 = FactoryBot.build(:organisation, :name => 'Age UK Elderly', :description => 'Care for older people', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.age-uk.co.uk/donate')
+      @org3 = FactoryBot.build(:organisation, name: 'Age UK Elderly', description: 'Care for older people', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.age-uk.co.uk/donate')
       @org3.categories << @category1
       allow(@org3).to receive :geocode
       @org3.save!
     end
 
     it 'should have a human readable name and charity commission id and ridiculous name' do
-      c = Category.new(:name => "Health",:charity_commission_id => 1, :charity_commission_name => "WELL BEING AND JOYOUS EXISTENCE")
-      expect(c.name).to eq("Health")
+      c = Category.new(name: 'Health',charity_commission_id: 1, charity_commission_name: 'WELL BEING AND JOYOUS EXISTENCE')
+      expect(c.name).to eq('Health')
       expect(c.charity_commission_id).to eq(1)
-      expect(c.charity_commission_name).to eq("WELL BEING AND JOYOUS EXISTENCE")
+      expect(c.charity_commission_name).to eq('WELL BEING AND JOYOUS EXISTENCE')
     end
 
     it 'has and belongs to many base_organisations' do
@@ -97,29 +97,29 @@ describe 'Category', :type => :model do
       end
     end
 
-    describe "#<=>" do
-      [{type: "what they do", id: 110}, {type: "who they help", id: 210}, {type: "how they help", id: 310}].each do |hash|
+    describe '#<=>' do
+      [{type: 'what they do', id: 110}, {type: 'who they help', id: 210}, {type: 'how they help', id: 310}].each do |hash|
         it "orders by name when category types are both #{hash[:type]}" do
-          alligator = Category.new(charity_commission_id: hash[:id], name: "Alligator") 
-          crocodile = Category.new(charity_commission_id: hash[:id] + 1, name: "Crocodile")
-          expect(alligator<=>crocodile).to eq -1
+          alligator = Category.new(charity_commission_id: hash[:id], name: 'Alligator') 
+          crocodile = Category.new(charity_commission_id: hash[:id] + 1, name: 'Crocodile')
+          expect(alligator<=>crocodile).to eq(-1)
         end
       end
-      [{first_type: "what they do", first_id: 100, second_id: 200, second_type: "who they help", result: -1},
-       {first_type: "who they help", first_id: 299, second_id: 399, second_type: "how they help", result: -1},
-       {first_type: "what they do", first_id: 199, second_id: 399, second_type: "how they help", result: -1},
-       {second_type: "what they do", second_id: 199, first_id: 200, first_type: "who they help", result: 1},
-       {second_type: "who they help", second_id: 299, first_id: 300, first_type: "how they help", result: 1},
-       {second_type: "what they do", second_id: 100, first_id: 300, first_type: "how they help", result: 1}].each do |hash|
+      [{first_type: 'what they do', first_id: 100, second_id: 200, second_type: 'who they help', result: -1},
+       {first_type: 'who they help', first_id: 299, second_id: 399, second_type: 'how they help', result: -1},
+       {first_type: 'what they do', first_id: 199, second_id: 399, second_type: 'how they help', result: -1},
+       {second_type: 'what they do', second_id: 199, first_id: 200, first_type: 'who they help', result: 1},
+       {second_type: 'who they help', second_id: 299, first_id: 300, first_type: 'how they help', result: 1},
+       {second_type: 'what they do', second_id: 100, first_id: 300, first_type: 'how they help', result: 1}].each do |hash|
          it "orders by type when the first category is #{hash[:first_type]} and the second category is #{hash[:second_type]}" do
-           alligator = Category.new(charity_commission_id: hash[:first_id], name: "Alligator") 
-           crocodile = Category.new(charity_commission_id: hash[:second_id], name: "Crocodile")
+           alligator = Category.new(charity_commission_id: hash[:first_id], name: 'Alligator') 
+           crocodile = Category.new(charity_commission_id: hash[:second_id], name: 'Crocodile')
            expect(alligator<=>crocodile).to eq hash[:result] 
          end
        end
        it 'returns 0 when category types and names are the same' do
-         alligator = Category.new(charity_commission_id: 310, name: "Alligator") 
-         crocodile = Category.new(charity_commission_id: 310, name: "Alligator") 
+         alligator = Category.new(charity_commission_id: 310, name: 'Alligator') 
+         crocodile = Category.new(charity_commission_id: 310, name: 'Alligator') 
          expect(alligator<=>crocodile).to eq 0
        end
     end

--- a/spec/models/csv_header_spec.rb
+++ b/spec/models/csv_header_spec.rb
@@ -1,9 +1,9 @@
 require_relative '../../app/models/csv_header'
 
-describe CSVHeader, :type => :model do
+describe CSVHeader, type: :model do
   let(:value) { CSVHeader.build }
 
-  context "column names" do
+  context 'column names' do
     subject { value }
 
     it { expect(subject.name).to eq 'Title' }

--- a/spec/models/description_humanizer_spec.rb
+++ b/spec/models/description_humanizer_spec.rb
@@ -1,7 +1,7 @@
 require 'active_support/all'
 require_relative '../../app/models/description_humanizer'
 
-describe DescriptionHumanizer, ".call", :type => :model do 
+describe DescriptionHumanizer, '.call', type: :model do 
   subject { DescriptionHumanizer.call(description) }
 
   context 'must be able to humanize a description' do 

--- a/spec/models/feature_spec.rb
+++ b/spec/models/feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Feature, :type => :model do
+describe Feature, type: :model do
   describe '::activate' do
     it 'sets ::active? from true to true' do
       Feature.create(name: :foo, active: true)

--- a/spec/models/first_capitals_humanizer_spec.rb
+++ b/spec/models/first_capitals_humanizer_spec.rb
@@ -1,6 +1,6 @@
 require 'active_support/all'
 require_relative '../../app/models/first_capitals_humanizer'
-describe FirstCapitalsHumanizer, ".call", :type => :model do 
+describe FirstCapitalsHumanizer, '.call', type: :model do 
   let(:phrase) { 'SOME WORDS FOR TESTING' }
 
   context 'should humanize a phrase' do 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -31,11 +31,11 @@ describe Location, type: :model do
         [80.0, 25.0] => [vol_op2]
       }
 
-      expect(Location.build_hash(input)).to eq({
+      expect(Location.build_hash(input)).to eq(
         Location.new(longitude: 12.0, latitude: 30.0) => [vol_op1],
         Location.new(longitude: 15.0, latitude: 45.0) => [vol_op2, vol_op3],
         Location.new(longitude: 80.0, latitude: 25.0) => [vol_op2]
-      })
+      )
     end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,32 +1,32 @@
 require 'rails_helper'
 
-describe Organisation, :type => :model do
+describe Organisation, type: :model do
 
   before do
     FactoryBot.factories.clear
     FactoryBot.find_definitions
 
-    @category1 = FactoryBot.create(:category, :charity_commission_id => 207)
-    @category2 = FactoryBot.create(:category, :charity_commission_id => 305)
-    @category3 = FactoryBot.create(:category, :charity_commission_id => 108)
-    @category4 = FactoryBot.create(:category, :charity_commission_id => 302)
-    @category5 = FactoryBot.create(:category, :charity_commission_id => 306)
-    @org1 = FactoryBot.build(:organisation, :email => "", :name => 'Harrow Bereavement Counselling', :description => 'Bereavement Counselling', :address => '84 pinner road', :postcode => 'HA1 4HA', :donation_info => 'www.harrow-bereavment.co.uk/donate')
+    @category1 = FactoryBot.create(:category, charity_commission_id: 207)
+    @category2 = FactoryBot.create(:category, charity_commission_id: 305)
+    @category3 = FactoryBot.create(:category, charity_commission_id: 108)
+    @category4 = FactoryBot.create(:category, charity_commission_id: 302)
+    @category5 = FactoryBot.create(:category, charity_commission_id: 306)
+    @org1 = FactoryBot.build(:organisation, email: '', name: 'Harrow Bereavement Counselling', description: 'Bereavement Counselling', address: '84 pinner road', postcode: 'HA1 4HA', donation_info: 'www.harrow-bereavment.co.uk/donate')
     @org1.save!
-    @org2 = FactoryBot.build(:organisation, :name => 'Indian Elders Association',:email => "",
-                              :description => 'Care for the elderly', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.indian-elders.co.uk/donate')
+    @org2 = FactoryBot.build(:organisation, name: 'Indian Elders Association',email: '',
+                              description: 'Care for the elderly', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.indian-elders.co.uk/donate')
     @org2.categories << @category1
     @org2.categories << @category2
     @org2.categories << @category3
     @org2.save!
-    @org3 = FactoryBot.build(:organisation, :email => "", :name => 'Age UK Elderly', :description => 'Care for older people', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.age-uk.co.uk/donate')
+    @org3 = FactoryBot.build(:organisation, email: '', name: 'Age UK Elderly', description: 'Care for older people', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.age-uk.co.uk/donate')
     @org3.categories << @category1
     @org3.save!
 
     FactoryBot.create :invitation_instructions
   end
 
-  describe "#gmaps4rails_marker_attrs" do
+  describe '#gmaps4rails_marker_attrs' do
 
     def build_org_with_computed_fields_and_updated_at org, updated_at = nil
       org.update_attributes(updated_at: updated_at) unless updated_at.nil?
@@ -41,7 +41,7 @@ describe Organisation, :type => :model do
 
     context 'has user' do
       before(:each) do
-        usr = FactoryBot.create(:user, :email => 'orgsuperadmin@org.org')
+        usr = FactoryBot.create(:user, email: 'orgsuperadmin@org.org')
         usr.confirm
         @org1.users << [usr]
         @org1.save!
@@ -77,7 +77,7 @@ describe Organisation, :type => :model do
   end
   context 'scopes for orphan orgs' do
     before(:each) do
-      @user = FactoryBot.create(:user, :email => 'hello@hello.com')
+      @user = FactoryBot.create(:user, email: 'hello@hello.com')
       @user.confirm
     end
 
@@ -115,8 +115,8 @@ describe Organisation, :type => :model do
   end
 
   context 'validating URLs' do
-    subject(:no_http_org) { FactoryBot.build(:organisation, :name => 'Harrow Bereavement Counselling', :description => 'Bereavement Counselling', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.harrow-bereavment.co.uk/donate') }
-    subject(:empty_website)  {FactoryBot.build(:organisation, :name => 'Harrow Bereavement Counselling', :description => 'Bereavement Counselling', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => '', :website => '')}
+    subject(:no_http_org) { FactoryBot.build(:organisation, name: 'Harrow Bereavement Counselling', description: 'Bereavement Counselling', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.harrow-bereavment.co.uk/donate') }
+    subject(:empty_website)  {FactoryBot.build(:organisation, name: 'Harrow Bereavement Counselling', description: 'Bereavement Counselling', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: '', website: '')}
     it 'if lacking protocol, http is prefixed to URL when saved' do
       no_http_org.save!
       expect(no_http_org.donation_info).to include('http://')
@@ -133,23 +133,23 @@ describe Organisation, :type => :model do
 
   context 'adding charity superadmins by email' do
     it 'handles an invalid email with an error' do
-      @org1.update_attributes_with_superadmin({:superadmin_email_to_add => 'user'})
+      @org1.update_attributes_with_superadmin(superadmin_email_to_add: 'user')
       expect(@org1.errors.messages[:superadministrator_email]).to include "The user email you entered,'user', is invalid"
     end
     it 'does not email when email is invalid' do
-      expect{
-        @org1.update_attributes_with_superadmin({:superadmin_email_to_add => 'user'})
-      }.not_to change(ActionMailer::Base.deliveries, :length)
+      expect do
+        @org1.update_attributes_with_superadmin(superadmin_email_to_add: 'user')
+      end.not_to change(ActionMailer::Base.deliveries, :length)
     end
     it 'does not update other attributes when email is invalid' do
-      @org1.update_attributes_with_superadmin({:superadmin_email_to_add => 'user', :name => 'Random name'})
+      @org1.update_attributes_with_superadmin(superadmin_email_to_add: 'user', name: 'Random name')
       expect(@org1.name).not_to eq 'Random name'
     end
 
     it 'handles a non-existent email by inviting user' do
       @org1.update_attributes_with_superadmin(
           superadmin_email_to_add: 'nonexistentuser@example.com'
-      )
+        )
       expect(@org1).to be_valid
       @org1.save!
       usr = User.find_by(email:'nonexistentuser@example.com')
@@ -157,7 +157,7 @@ describe Organisation, :type => :model do
       expect(usr.organisation).to eq @org1
     end
     it 'does not update other attributes when there is an invalid email' do
-      expect(@org1.update_attributes_with_superadmin({:name => 'New name',:superadmin_email_to_add => 'user'})).to be_nil
+      expect(@org1.update_attributes_with_superadmin(name: 'New name',superadmin_email_to_add: 'user')).to be_nil
       expect(@org1.name).not_to eq 'New name'
     end
     it 'handles a nil email' do
@@ -181,17 +181,17 @@ describe Organisation, :type => :model do
       expect(@org1.users).to include usr
     end
     it 'uses org admin mailer to email existent user when upgraded to org admin' do
-      usr = FactoryBot.create(:user, :email => 'user@example.org')
+      usr = FactoryBot.create(:user, email: 'user@example.org')
       mockMessage = double('message')
       expect(mockMessage).to receive :deliver_now
       expect(OrgAdminMailer).to receive_message_chain(:new_org_admin).with(@org1, [usr.email]).and_return(mockMessage)
-      @org1.update_attributes_with_superadmin({:superadmin_email_to_add => usr.email})
+      @org1.update_attributes_with_superadmin(superadmin_email_to_add: usr.email)
     end
     it 'updates other attributes with blank email' do
       @org1.update_attributes_with_superadmin(
           name: 'New name',
           superadmin_email_to_add: ''
-      )
+        )
       expect(@org1.valid?).to be true
       @org1.save!
       expect(@org1.name).to eq 'New name'
@@ -201,7 +201,7 @@ describe Organisation, :type => :model do
       @org1.update_attributes_with_superadmin(
           name: 'New name',
           superadmin_email_to_add: usr.email
-      )
+        )
       expect(@org1.valid?).to be true
       @org1.save!
       expect(@org1.name).to eq 'New name'
@@ -253,9 +253,9 @@ describe Organisation, :type => :model do
     end
 
     it 'must be able to generate multiple Organisations from text file' do
-      expect{
+      expect do
         Organisation.import_addresses 'db/data.csv', 2
-      }.to change(Organisation, :count).by 2
+      end.to change(Organisation, :count).by 2
     end
 
     it 'must fail gracefully when encountering error in generating multiple Organisations from text file' do
@@ -277,7 +277,7 @@ describe Organisation, :type => :model do
       expect(org.postcode).to eq('No information recorded')
       expect(org.website).to eq('http://www.harrow-baptist.org.uk')
       expect(org.telephone).to eq('020 8863 7837')
-      expect(org.donation_info).to eq("")
+      expect(org.donation_info).to eq('')
     end
 
     it 'must be able to handle no address in text representation' do
@@ -289,7 +289,7 @@ describe Organisation, :type => :model do
       expect(org.postcode).to eq('No information recorded')
       expect(org.website).to eq('http://www.harrow-baptist.org.uk')
       expect(org.telephone).to eq('020 8863 7837')
-      expect(org.donation_info).to eq("")
+      expect(org.donation_info).to eq('')
     end
 
     it 'must be able to generate Organisation from text representation ensuring words in correct case and postcode is extracted from address' do
@@ -301,7 +301,7 @@ describe Organisation, :type => :model do
       expect(org.postcode).to eq('HA1 4HZ')
       expect(org.website).to eq('http://www.harrow-baptist.org.uk')
       expect(org.telephone).to eq('020 8863 7837')
-      expect(org.donation_info).to eq("")
+      expect(org.donation_info).to eq('')
     end
 
 
@@ -329,7 +329,7 @@ describe Organisation, :type => :model do
       Organisation.create_from_array(row, true)
     end
 
-    context "importing category relations" do
+    context 'importing category relations' do
       let(:fields) do
         CSV.parse('HARROW BEREAVEMENT COUNSELLING,1129832,NO INFORMATION RECORDED,MR JOHN ROSS NEWBY,"HARROW BAPTIST CHURCH, COLLEGE ROAD, HARROW, HA1 4HZ",http://www.harrow-baptist.org.uk,020 8863 7837,2009-05-27,,,,,,http://OpenlyLocal.com/charities/57879-HARROW-BAPTIST-CHURCH,,,,,"207,305,108,302,306",false,2010-09-20T21:38:52+01:00,2010-08-22T22:19:07+01:00,2012-04-15T11:22:12+01:00,*****')
       end
@@ -343,10 +343,10 @@ describe Organisation, :type => :model do
         CSV::Row.new(@headers, fields_cat_missing.flatten)
       end
       it 'must be able to avoid org category relations from text file when org does not exist' do
-        @org4 = FactoryBot.build(:organisation, :name => 'Fellowship For Management In Food Distribution', :description => 'Bereavement Counselling', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.harrow-bereavment.co.uk/donate')
+        @org4 = FactoryBot.build(:organisation, name: 'Fellowship For Management In Food Distribution', description: 'Bereavement Counselling', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.harrow-bereavment.co.uk/donate')
         @org4.save!
         [102,206,302].each do |id|
-          FactoryBot.build(:category, :charity_commission_id => id).save!
+          FactoryBot.build(:category, charity_commission_id: id).save!
         end
         attempted_number_to_import = 2
         number_cat_org_relations_generated = 3
@@ -355,7 +355,7 @@ describe Organisation, :type => :model do
         }).to change(CategoryOrganisation, :count).by(number_cat_org_relations_generated)
       end
 
-      it "allows us to import categories" do
+      it 'allows us to import categories' do
         org = Organisation.import_categories_from_array(row)
         expect(org.categories.length).to eq 5
         [207,305,108,302,306].each do |id|
@@ -371,12 +371,12 @@ describe Organisation, :type => :model do
         }).to change(Organisation, :count).by(0)
       end
 
-      it "should import categories when matching org is found" do
+      it 'should import categories when matching org is found' do
         expect(Organisation).to receive(:check_columns_in).with(row)
         expect(Organisation).to receive(:find_by_name).with('Harrow Bereavement Counselling').and_return @org1
         array = double('Array')
-        [{:cc_id => 207, :cat => @cat1}, {:cc_id => 305, :cat => @cat2}, {:cc_id => 108, :cat => @cat3},
-         {:cc_id => 302, :cat => @cat4}, {:cc_id => 306, :cat => @cat5}]. each do |cat_hash|
+        [{cc_id: 207, cat: @cat1}, {cc_id: 305, cat: @cat2}, {cc_id: 108, cat: @cat3},
+         {cc_id: 302, cat: @cat4}, {cc_id: 306, cat: @cat5}]. each do |cat_hash|
           expect(Category).to receive(:find_by_charity_commission_id).with(cat_hash[:cc_id]).and_return(cat_hash[:cat])
           expect(array).to receive(:<<).with(cat_hash[:cat])
         end
@@ -385,14 +385,14 @@ describe Organisation, :type => :model do
         expect(org).not_to be_nil
       end
 
-      it "should not import categories when no matching organisation" do
+      it 'should not import categories when no matching organisation' do
         expect(Organisation).to receive(:check_columns_in).with(row)
         expect(Organisation).to receive(:find_by_name).with('Harrow Bereavement Counselling').and_return nil
         org = Organisation.import_categories_from_array(row)
         expect(org).to be_nil
       end
 
-      it "should not import categories when none are listed" do
+      it 'should not import categories when none are listed' do
         expect(Organisation).to receive(:check_columns_in).with(row_cat_missing)
         expect(Organisation).to receive(:find_by_name).with('Harrow Bereavement Counselling').and_return @org1
         org = Organisation.import_categories_from_array(row_cat_missing)
@@ -405,9 +405,9 @@ describe Organisation, :type => :model do
   # org = Organisation.new(:address =>"blah", :gmaps=> ";DROP DATABASE;")
   # org = Organisation.new(:address =>"blah", :name=> ";DROP DATABASE;")
 
-  describe "importing emails" do
-    it "should have a method import_emails" do
-      filename = "db/emails.csv"
+  describe 'importing emails' do
+    it 'should have a method import_emails' do
+      filename = 'db/emails.csv'
       expect(Organisation).to receive(:add_email).twice.and_call_original
       expect(Organisation).to receive(:import).with(filename,2,false).and_call_original
      # do |&arg|
@@ -418,29 +418,29 @@ describe Organisation, :type => :model do
     end
 
     it 'should handle absence of org gracefully' do
-      expect(Organisation).to receive(:where).with("UPPER(name) LIKE ? ", "%I LOVE PEOPLE%").and_return(nil)
+      expect(Organisation).to receive(:where).with('UPPER(name) LIKE ? ', '%I LOVE PEOPLE%').and_return(nil)
       expect(lambda{
         response = Organisation.add_email(fields = CSV.parse('i love people,,,,,,,test@example.org')[0],true)
         expect(response).to eq "i love people was not found\n"
       }).not_to raise_error
     end
 
-    it "should add email to org" do
-      expect(Organisation).to receive(:where).with("UPPER(name) LIKE ? ", "%FRIENDLY%").and_return([@org1])
+    it 'should add email to org' do
+      expect(Organisation).to receive(:where).with('UPPER(name) LIKE ? ', '%FRIENDLY%').and_return([@org1])
       expect(@org1).to receive(:email=).with('test@example.org')
       expect(@org1).to receive(:save)
       Organisation.add_email(fields = CSV.parse('friendly,,,,,,,test@example.org')[0],true)
     end
 
-    it "should add blank string email to org if email is NULL" do
-      expect(Organisation).to receive(:where).with("UPPER(name) LIKE ? ", "%FRIENDLY%").and_return([@org1])
-      expect{
+    it 'should add blank string email to org if email is NULL' do
+      expect(Organisation).to receive(:where).with('UPPER(name) LIKE ? ', '%FRIENDLY%').and_return([@org1])
+      expect do
         Organisation.add_email(fields = CSV.parse('friendly,,,,,,,')[0],true)
-      }.not_to change(@org1, :email)
+      end.not_to change(@org1, :email)
     end
 
-    it "should add email to org even with case mismatch" do
-      expect(Organisation).to receive(:where).with("UPPER(name) LIKE ? ", "%FRIENDLY%").and_return([@org1])
+    it 'should add email to org even with case mismatch' do
+      expect(Organisation).to receive(:where).with('UPPER(name) LIKE ? ', '%FRIENDLY%').and_return([@org1])
       expect(@org1).to receive(:email=).with('test@example.org')
       expect(@org1).to receive(:save)
       Organisation.add_email(fields = CSV.parse('friendly,,,,,,,test@example.org')[0],true)
@@ -449,7 +449,7 @@ describe Organisation, :type => :model do
     it 'should not add email to org when it has an existing email' do
       @org1.email = 'something@example.com'
       @org1.save!
-      expect(Organisation).to receive(:where).with("UPPER(name) LIKE ? ", "%FRIENDLY%").and_return([@org1])
+      expect(Organisation).to receive(:where).with('UPPER(name) LIKE ? ', '%FRIENDLY%').and_return([@org1])
       expect(@org1).not_to receive(:email=).with('test@example.org')
       expect(@org1).not_to receive(:save)
       Organisation.add_email(fields = CSV.parse('friendly,,,,,,,test@example.org')[0],true)
@@ -473,33 +473,33 @@ describe Organisation, :type => :model do
                      org.id+1 => org.email},
                      resend_invitation: false}
     end
-    let(:invited_user) { User.where("users.organisation_id IS NOT null").first }
+    let(:invited_user) { User.where('users.organisation_id IS NOT null').first }
 
     before do
       BatchInviteJob.new(params, current_user).run
       expect(invited_user.organisation_id).to eq org.id
     end
 
-    it "unsets user-organisation association of users of the organisation that"\
-       "are invited_not_accepted" do
-      expect{
+    it 'unsets user-organisation association of users of the organisation that'\
+       'are invited_not_accepted' do
+      expect do
         org.uninvite_users
         invited_user.reload
-      }.to change(invited_user, :organisation_id).from(org.id).to(nil)
+      end.to change(invited_user, :organisation_id).from(org.id).to(nil)
     end
 
-    it "happens when email is updated" do
-      expect{
+    it 'happens when email is updated' do
+      expect do
         org.update_attributes(email: 'hello@email.com')
         invited_user.reload
-      }.to change(invited_user, :organisation_id).from(org.id).to(nil)
+      end.to change(invited_user, :organisation_id).from(org.id).to(nil)
     end
 
     it "doesn't happen when other attributes are updated" do
-      expect{
+      expect do
         org.update_attributes(website: 'www.abc.com')
         invited_user.reload
-      }.not_to change(invited_user, :organisation_id)
+      end.not_to change(invited_user, :organisation_id)
     end
   end
   
@@ -511,17 +511,17 @@ describe Organisation, :type => :model do
   end
 end
 
-describe Organisation, :type => :model do
+describe Organisation, type: :model do
 
   before do
     FactoryBot.factories.clear
     FactoryBot.find_definitions
 
-    @org1 = FactoryBot.build(:organisation, :name => 'Harrow Bereavement Counselling', :description => 'Bereavement Counselling', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.harrow-bereavment.co.uk/donate')
+    @org1 = FactoryBot.build(:organisation, name: 'Harrow Bereavement Counselling', description: 'Bereavement Counselling', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.harrow-bereavment.co.uk/donate')
     @org1.save!
-    @org2 = FactoryBot.build(:organisation, :name => 'Indian Elders Associaton', :description => 'Care for the elderly', :address => '64 pinner road', :postcode => 'HA1 4HZ', :latitude => 77, :longitude => 77, :donation_info => 'www.indian-elders.co.uk/donate')
+    @org2 = FactoryBot.build(:organisation, name: 'Indian Elders Associaton', description: 'Care for the elderly', address: '64 pinner road', postcode: 'HA1 4HZ', latitude: 77, longitude: 77, donation_info: 'www.indian-elders.co.uk/donate')
     @org2.save!
-    @org3 = FactoryBot.build(:organisation, :name => 'Age UK Elderly', :description => 'Care for older people', :address => '64 pinner road', :postcode => 'HA1 4HZ', :donation_info => 'www.age-uk.co.uk/donate')
+    @org3 = FactoryBot.build(:organisation, name: 'Age UK Elderly', description: 'Care for older people', address: '64 pinner road', postcode: 'HA1 4HZ', donation_info: 'www.age-uk.co.uk/donate')
     @org3.save!
   end
   
@@ -538,7 +538,7 @@ describe Organisation, :type => :model do
 
   describe 'run_geocode?' do
     it 'should return true if address is changed' do
-      @org1.address = "asjkdhas,ba,asda"
+      @org1.address = 'asjkdhas,ba,asda'
       expect(@org1.run_geocode?).to be true
     end
 
@@ -566,44 +566,44 @@ describe Organisation, :type => :model do
 end
 
 describe Organisation, '::filter_by_categories' do
-  let!(:category1) { create(:category, :charity_commission_id => 108) }
-  let!(:category2) { create(:category, :charity_commission_id => 205) }
+  let!(:category1) { create(:category, charity_commission_id: 108) }
+  let!(:category2) { create(:category, charity_commission_id: 205) }
   # not initialized!
-  let(:category3) { create(:category, :charity_commission_id => 307) }
+  let(:category3) { create(:category, charity_commission_id: 307) }
 
   let!(:org1) do
     create(
       :organisation,
-      :email => "",
-      :name => 'Harrow Bereavement Counselling',
-      :description => 'Bereavement Counselling',
-      :address => '64 pinner road',
-      :postcode => 'HA1 4HZ',
-      :donation_info => 'www.harrow-bereavment.co.uk/donate',
+      email: '',
+      name: 'Harrow Bereavement Counselling',
+      description: 'Bereavement Counselling',
+      address: '64 pinner road',
+      postcode: 'HA1 4HZ',
+      donation_info: 'www.harrow-bereavment.co.uk/donate',
     )
   end
 
   let!(:org2) do
     create(
       :organisation,
-      :name => 'Indian Elders Association',
-      :email => "",
-      :description => 'Care for the elderly',
-      :address => '64 pinner road',
-      :postcode => 'HA1 4HZ',
-      :donation_info => 'www.indian-elders.co.uk/donate'
+      name: 'Indian Elders Association',
+      email: '',
+      description: 'Care for the elderly',
+      address: '64 pinner road',
+      postcode: 'HA1 4HZ',
+      donation_info: 'www.indian-elders.co.uk/donate'
     ).tap { |o| o.categories << category1 ; o.categories << category2 }
   end
 
   let!(:org3) do
     create(
       :organisation,
-      :email => "",
-      :name => 'Age UK Elderly',
-      :description => 'Care for older people',
-      :address => '64 pinner road',
-      :postcode => 'HA1 4HZ',
-      :donation_info => 'www.age-uk.co.uk/donate',
+      email: '',
+      name: 'Age UK Elderly',
+      description: 'Care for older people',
+      address: '64 pinner road',
+      postcode: 'HA1 4HZ',
+      donation_info: 'www.age-uk.co.uk/donate',
     ).tap { |o| o.categories  << category1 }
   end
 
@@ -654,7 +654,7 @@ describe Organisation, '::filter_by_categories' do
     it 'no duplicates' do
       expect(
           Organisation.filter_by_categories([category1.id, category2.id]).map.count
-      ).to eq 1
+        ).to eq 1
     end
 
     it 'categories in join table' do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Page, :type => :model do
+describe Page, type: :model do
   context 'single page examples' do
     before :each do
       @page = FactoryBot.create(:page)
@@ -20,9 +20,9 @@ describe Page, :type => :model do
   end
   describe '::create!' do
     it 'can set the link_visible attribute to be false' do
-      unlinked_page = Page.create!(:name => 'MyString', 
-                                   :permalink => 'my_link',
-                                   :link_visible => false)
+      unlinked_page = Page.create!(name: 'MyString', 
+                                   permalink: 'my_link',
+                                   link_visible: false)
       expect(unlinked_page.reload.link_visible).to eq false
     end
   end
@@ -31,20 +31,20 @@ describe Page, :type => :model do
     before :each do
       @linked_page = FactoryBot.create(:page)
       @second_linked_page = FactoryBot.create(:page,
-                                               :name => 'An interesting page',
-                                               :permalink => 'interesting')
+                                               name: 'An interesting page',
+                                               permalink: 'interesting')
       @unlinked_page = FactoryBot.create(:page,
-                                          :name => 'A boring page',
-                                          :permalink => 'bore',
-                                          :link_visible => false)
+                                          name: 'A boring page',
+                                          permalink: 'bore',
+                                          link_visible: false)
     end
     
     describe '::visible_links' do
       it 'returns a collection of links to the pages that have visible links' do
         
         expect(Page.visible_links).to eq \
-          [{:name => 'About Us', :permalink => 'about'},
-           {:name => 'An interesting page', :permalink => 'interesting'}]
+          [{name: 'About Us', permalink: 'about'},
+           {name: 'An interesting page', permalink: 'interesting'}]
       end
     end
   end

--- a/spec/models/proposed_organisation_edit_spec.rb
+++ b/spec/models/proposed_organisation_edit_spec.rb
@@ -2,27 +2,29 @@ require 'rails_helper'
 def check_viewability(boolean, usr, array_of_symbols)
   array_of_symbols.each do |sym|
     it "should indicate#{boolean ? '' : ' NOT'} viewable for #{sym}" do
-      user = case usr
-             when :regular_user
-          regular_user 
-             when :siteadmin
+      user =
+        case usr
+        when :regular_user
+          regular_user
+        when :siteadmin
           siteadmin
-             when :superadmin
+        when :superadmin
           superadmin
         else
           {}
         end
       expect(proposed_edit.viewable_field?(sym, by: user)).to be boolean
     end
-  end    
+  end
 end
 def check_editability(boolean, usr, array_of_symbols)
   array_of_symbols.each do |sym|
     it "should indicate#{boolean ? '' : ' NOT'} editable for #{sym}" do
-      user = case usr
-             when :regular_user
-          regular_user 
-             when :siteadmin
+      user =
+        case usr
+        when :regular_user
+          regular_user
+        when :siteadmin
           siteadmin
         else
           {}
@@ -35,35 +37,53 @@ end
 describe ProposedOrganisationEdit do
 
   let(:regular_user) do
-    FactoryBot.create(:user, email: 'regularjoe@example.com', password: 'asdf1234', password_confirmation:       'asdf1234', siteadmin: false)
+    FactoryBot.create(
+      :user,
+      email: 'regularjoe@example.com',
+      password: 'asdf1234',
+      password_confirmation:       'asdf1234',
+      siteadmin: false)
   end
   let(:superadmin) do
-    FactoryBot.create(:user, email: 'superadmin@example.com', password: 'asdf1234', password_confirmation:       'asdf1234', superadmin: true)
+    FactoryBot.create(
+      :user,
+      email: 'superadmin@example.com',
+      password: 'asdf1234',
+      password_confirmation:       'asdf1234',
+      superadmin: true)
   end
 
   let(:siteadmin) do
-    FactoryBot.create(:user, email: 'siteadmin@example.com', password: 'asdf1234', password_confirmation:       'asdf1234', siteadmin: true)
+    FactoryBot.create(
+      :user,
+      email: 'siteadmin@example.com',
+      password: 'asdf1234',
+      password_confirmation:       'asdf1234',
+      siteadmin: true)
   end
 
   let(:org) do
-    FactoryBot.create(:organisation,
-                       name: 'Harrow Bereavement Counselling',
-                       description: 'Bereavement Counselling',
-                       address: '64 pinner road',
-                       postcode: 'HA1 4HZ',
-                       donation_info: 'www.harrow-bereavment.co.uk/donate')
+    FactoryBot.create(
+      :organisation,
+      name: 'Harrow Bereavement Counselling',
+      description: 'Bereavement Counselling',
+      address: '64 pinner road',
+      postcode: 'HA1 4HZ',
+      donation_info: 'www.harrow-bereavment.co.uk/donate')
   end
 
   let!(:proposed_edit) do
-    FactoryBot.create(:proposed_organisation_edit,
-                       organisation: org )
+    FactoryBot.create(
+      :proposed_organisation_edit,
+      organisation: org )
   end
-  
+
   describe '::still_pending' do
     let(:archived_edit) do
-      FactoryBot.create(:proposed_organisation_edit,
-                         organisation: org,
-                         archived: true)
+      FactoryBot.create(
+        :proposed_organisation_edit,
+        organisation: org,
+        archived: true)
     end
     it 'should return all edits that are not yet archived' do
       expect(ProposedOrganisationEdit.all).to include archived_edit
@@ -72,14 +92,14 @@ describe ProposedOrganisationEdit do
   end
 
   it 'should soft delete associated edits when org is soft deleted' do
-      org.destroy
-      expect(ProposedOrganisationEdit.all).not_to include proposed_edit
-      expect(ProposedOrganisationEdit.with_deleted).to include proposed_edit
+    org.destroy
+    expect(ProposedOrganisationEdit.all).not_to include proposed_edit
+    expect(ProposedOrganisationEdit.with_deleted).to include proposed_edit
   end
 
   describe '#viewable_field?' do
     context 'when publish fields are all false and user is regular user' do
-      before do 
+      before do
         org.update(publish_email: false)
       end
       check_viewability(false, :regular_user, [:address, :telephone, :email])
@@ -108,15 +128,15 @@ describe ProposedOrganisationEdit do
       end
       check_viewability(true, :superadmin, [:address, :telephone, :email])
     end
-   context 'when publish fields are all true and user is superadmin' do
+    context 'when publish fields are all true and user is superadmin' do
       before do
         org.update(publish_phone: true, publish_address: true)
       end
       check_viewability(true, :superadmin, [:address, :telephone, :email])
-   end
+    end
   end
   describe '#editable?' do
-    
+
     check_editability(false, :regular_user, [:address,:telephone])
     check_editability(true, :regular_user, [:name, :description, :postcode, :website, :donation_info, :email])
 
@@ -129,7 +149,7 @@ describe ProposedOrganisationEdit do
       check_editability(true, :regular_user, [:address,:telephone])
       check_editability(false, :regular_user, [:email])
     end
-    
+
     context 'when editor is siteadmin' do
       before do 
         org.update(publish_email: false)
@@ -158,10 +178,14 @@ describe ProposedOrganisationEdit do
   describe '#accept' do
     context 'update with params' do
       let(:org) do
-        FactoryBot.create(:organisation, name: 'Harrow Bereavement Counselling',
-                                   description: 'Bereavement Counselling', address: '64 pinner road', postcode: 'HA1 4HZ',
-                                   donation_info: 'www.harrow-bereavment.co.uk/donate')
-      end      
+        FactoryBot.create(
+          :organisation,
+          name: 'Harrow Bereavement Counselling',
+          description: 'Bereavement Counselling',
+          address: '64 pinner road',
+          postcode: 'HA1 4HZ',
+          donation_info: 'www.harrow-bereavment.co.uk/donate')
+      end
       let(:proposed_edit){FactoryBot.create(:proposed_organisation_edit, organisation: org )}
       it 'updates the name attribute' do
         expect do

--- a/spec/models/proposed_organisation_edit_spec.rb
+++ b/spec/models/proposed_organisation_edit_spec.rb
@@ -3,11 +3,11 @@ def check_viewability(boolean, usr, array_of_symbols)
   array_of_symbols.each do |sym|
     it "should indicate#{boolean ? '' : ' NOT'} viewable for #{sym}" do
       user = case usr
-        when :regular_user
+             when :regular_user
           regular_user 
-        when :siteadmin
+             when :siteadmin
           siteadmin
-        when :superadmin
+             when :superadmin
           superadmin
         else
           {}
@@ -20,9 +20,9 @@ def check_editability(boolean, usr, array_of_symbols)
   array_of_symbols.each do |sym|
     it "should indicate#{boolean ? '' : ' NOT'} editable for #{sym}" do
       user = case usr
-        when :regular_user
+             when :regular_user
           regular_user 
-        when :siteadmin
+             when :siteadmin
           siteadmin
         else
           {}
@@ -35,38 +35,35 @@ end
 describe ProposedOrganisationEdit do
 
   let(:regular_user) do
-    FactoryBot.create(:user, :email => "regularjoe@example.com", :password => 'asdf1234', :password_confirmation =>
-      'asdf1234', :siteadmin => false)
-   end
+    FactoryBot.create(:user, email: 'regularjoe@example.com', password: 'asdf1234', password_confirmation:       'asdf1234', siteadmin: false)
+  end
   let(:superadmin) do
-    FactoryBot.create(:user, :email => "superadmin@example.com", :password => 'asdf1234', :password_confirmation =>
-      'asdf1234', :superadmin => true)
-   end
+    FactoryBot.create(:user, email: 'superadmin@example.com', password: 'asdf1234', password_confirmation:       'asdf1234', superadmin: true)
+  end
 
   let(:siteadmin) do
-    FactoryBot.create(:user, :email => "siteadmin@example.com", :password => 'asdf1234', :password_confirmation =>
-      'asdf1234', :siteadmin => true)
-   end
+    FactoryBot.create(:user, email: 'siteadmin@example.com', password: 'asdf1234', password_confirmation:       'asdf1234', siteadmin: true)
+  end
 
   let(:org) do
     FactoryBot.create(:organisation,
-                       :name => 'Harrow Bereavement Counselling',
-                       :description => 'Bereavement Counselling',
-                       :address => '64 pinner road',
-                       :postcode => 'HA1 4HZ',
-                       :donation_info => 'www.harrow-bereavment.co.uk/donate')
+                       name: 'Harrow Bereavement Counselling',
+                       description: 'Bereavement Counselling',
+                       address: '64 pinner road',
+                       postcode: 'HA1 4HZ',
+                       donation_info: 'www.harrow-bereavment.co.uk/donate')
   end
 
   let!(:proposed_edit) do
     FactoryBot.create(:proposed_organisation_edit,
-                       :organisation => org )
+                       organisation: org )
   end
   
   describe '::still_pending' do
     let(:archived_edit) do
       FactoryBot.create(:proposed_organisation_edit,
-                         :organisation => org,
-                         :archived => true)
+                         organisation: org,
+                         archived: true)
     end
     it 'should return all edits that are not yet archived' do
       expect(ProposedOrganisationEdit.all).to include archived_edit
@@ -83,40 +80,40 @@ describe ProposedOrganisationEdit do
   describe '#viewable_field?' do
     context 'when publish fields are all false and user is regular user' do
       before do 
-        org.update(:publish_email => false)
+        org.update(publish_email: false)
       end
       check_viewability(false, :regular_user, [:address, :telephone, :email])
     end
     context 'when publish fields are all true and user is regular user' do
       before do 
-        org.update(:publish_phone => true, :publish_address => true)
+        org.update(publish_phone: true, publish_address: true)
       end
       check_viewability(true, :regular_user, [:address, :telephone, :email])
     end
     context 'when publish fields are all false but user is siteadmin' do
       before do
-        org.update(:publish_email => false)
+        org.update(publish_email: false)
       end
       check_viewability(true, :siteadmin, [:address, :telephone, :email])
     end
     context 'when publish fields are all true and user is siteadmin' do
       before do
-        org.update(:publish_phone => true, :publish_address => true)
+        org.update(publish_phone: true, publish_address: true)
       end
       check_viewability(true, :siteadmin, [:address, :telephone, :email])
     end
     context 'when publish fields are all false but user is superadmin' do
       before do
-        org.update(:publish_email => false)
+        org.update(publish_email: false)
       end
       check_viewability(true, :superadmin, [:address, :telephone, :email])
     end
    context 'when publish fields are all true and user is superadmin' do
       before do
-        org.update(:publish_phone => true, :publish_address => true)
+        org.update(publish_phone: true, publish_address: true)
       end
       check_viewability(true, :superadmin, [:address, :telephone, :email])
-    end
+   end
   end
   describe '#editable?' do
     
@@ -125,9 +122,9 @@ describe ProposedOrganisationEdit do
 
     context 'when publish field settings are changed' do
       before do
-        org.update(:publish_phone => true,
-                   :publish_address => true,
-                   :publish_email => false)
+        org.update(publish_phone: true,
+                   publish_address: true,
+                   publish_email: false)
       end
       check_editability(true, :regular_user, [:address,:telephone])
       check_editability(false, :regular_user, [:email])
@@ -135,14 +132,14 @@ describe ProposedOrganisationEdit do
     
     context 'when editor is siteadmin' do
       before do 
-        org.update(:publish_email => false)
+        org.update(publish_email: false)
       end
       check_editability(true, :siteadmin, [:address, :telephone, :email])
     end
   end
 
   describe '#non_published_editable_fields' do
-    let(:org){FactoryBot.create(:organisation, :name => "Happy Org", :publish_email => false)}
+    let(:org){FactoryBot.create(:organisation, name: 'Happy Org', publish_email: false)}
     context 'all fields are private' do
       it 'returns email, telephone and address but nothing else' do
         expect(proposed_edit.non_published_generally_editable_fields).to include :email, :telephone, :address
@@ -150,7 +147,7 @@ describe ProposedOrganisationEdit do
       end
     end
     context 'address is public' do
-      let(:org){FactoryBot.create(:organisation, :name => "Happy Org", :publish_email => false, :publish_address => true)}
+      let(:org){FactoryBot.create(:organisation, name: 'Happy Org', publish_email: false, publish_address: true)}
       it 'returns email, and telephone but not address' do
         expect(proposed_edit.non_published_generally_editable_fields).to include :email, :telephone
         expect(proposed_edit.non_published_generally_editable_fields).not_to include :address, :name, :postcode, :description, :donation_info, :website
@@ -158,39 +155,41 @@ describe ProposedOrganisationEdit do
     end
   end
 
-  describe "#accept" do
+  describe '#accept' do
     context 'update with params' do
-      let(:org){FactoryBot.create(:organisation, :name => 'Harrow Bereavement Counselling',
-                                   :description => 'Bereavement Counselling', :address => '64 pinner road', :postcode => 'HA1 4HZ',
-                                   :donation_info => 'www.harrow-bereavment.co.uk/donate')}
-      let(:proposed_edit){FactoryBot.create(:proposed_organisation_edit, :organisation => org )}
+      let(:org) do
+        FactoryBot.create(:organisation, name: 'Harrow Bereavement Counselling',
+                                   description: 'Bereavement Counselling', address: '64 pinner road', postcode: 'HA1 4HZ',
+                                   donation_info: 'www.harrow-bereavment.co.uk/donate')
+      end      
+      let(:proposed_edit){FactoryBot.create(:proposed_organisation_edit, organisation: org )}
       it 'updates the name attribute' do
-        expect{
-          proposed_edit.accept("name" => "Care for the Elderly")
-        }.to change(org, :name).to("Care for the Elderly")
+        expect do
+          proposed_edit.accept('name' => 'Care for the Elderly')
+        end.to change(org, :name).to('Care for the Elderly')
       end
       it do
-        expect{
-          proposed_edit.accept("name" => "Care for the Elderly")
-        }.to change(proposed_edit, :accepted).from(false).to true
+        expect do
+          proposed_edit.accept('name' => 'Care for the Elderly')
+        end.to change(proposed_edit, :accepted).from(false).to true
       end
       it do
-        expect{
-          proposed_edit.accept("name" => "Care for the Elderly")
-        }.to change(proposed_edit, :archived).from(false).to true
+        expect do
+          proposed_edit.accept('name' => 'Care for the Elderly')
+        end.to change(proposed_edit, :archived).from(false).to true
       end
     end
   end
 
   describe '#has_proposed_edit?' do
     context 'when an edit to :name has not been proposed' do
-      let(:proposed_edit){FactoryBot.create(:proposed_organisation_edit, :organisation => org, :name => 'Harrow Bereavement Counselling' )}
+      let(:proposed_edit){FactoryBot.create(:proposed_organisation_edit, organisation: org, name: 'Harrow Bereavement Counselling' )}
       it 'should indicate an edit has not been proposed to :name' do 
         expect(proposed_edit.has_proposed_edit?(:name)).to be false
       end
     end
     context 'when an edit to :name has been proposed' do
-      let(:proposed_edit){FactoryBot.create(:proposed_organisation_edit, :organisation => org, :name => 'Mourning Loved Ones' )}
+      let(:proposed_edit){FactoryBot.create(:proposed_organisation_edit, organisation: org, name: 'Mourning Loved Ones' )}
       it 'should indicate an edit has been proposed' do 
         expect(proposed_edit.has_proposed_edit?(:name)).to be true
       end

--- a/spec/models/proposed_organisation_spec.rb
+++ b/spec/models/proposed_organisation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ProposedOrganisation, :type => :model do
+describe ProposedOrganisation, type: :model do
   let!(:proposed_org){FactoryBot.create :proposed_organisation}
   let!(:owner){proposed_org.users.first}
   let(:new_org){proposed_org.accept_proposal}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-describe User, :type => :model do
+describe User, type: :model do
 
-  let (:model) { mock_model("Organisation", :_read_attribute => 1)}
+  let (:model) { mock_model('Organisation', _read_attribute: 1)}
 
   context 'invited users scope' do
     before(:each) do
@@ -63,7 +63,7 @@ describe User, :type => :model do
     end
 
     context 'is not superadmin' do
-      let(:non_associated_model) { mock_model("Organisation") }
+      let(:non_associated_model) { mock_model('Organisation') }
       subject(:user) { create(:user, superadmin: false, organisation: model) }
 
       it 'can edit associated organisation' do
@@ -210,7 +210,7 @@ describe User, :type => :model do
 
   context '#request_admin_status' do
     let(:user) { FactoryBot.build(:user) }
-    let(:organisation_id) { 12345 }
+    let(:organisation_id) { 12_345 }
 
     it 'update pending organisation id' do
       user.request_admin_status organisation_id
@@ -251,7 +251,7 @@ describe User, :type => :model do
     end
   end
 
-  describe "#pending_org_admin?" do
+  describe '#pending_org_admin?' do
     let(:user) { FactoryBot.create :user_stubbed_organisation }
     let(:other_org) { FactoryBot.create :organisation }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,8 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RSPEC'] = 'rspec'
-ENV["RAILS_ENV"] ||= 'test'
+ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
-require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -29,7 +29,7 @@ end
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -62,14 +62,14 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  config.include Devise::Test::ControllerHelpers, :type => :view
-  config.include Devise::Test::ControllerHelpers, :type => :controller
-  config.include Devise::Test::ControllerHelpers, :type => :helper
+  config.include Devise::Test::ControllerHelpers, type: :view
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :helper
 
   config.include FactoryBot::Syntax::Methods
-  config.include ControllerHelpers, :helpers => :controllers
-  config.include RequestHelpers, :helpers => :requests
-  config.include ViewHelpers, :helpers => :views
+  config.include ControllerHelpers, helpers: :controllers
+  config.include RequestHelpers, helpers: :requests
+  config.include ViewHelpers, helpers: :views
 
   config.before(:each) { ActionMailer::Base.deliveries.clear }
 end

--- a/spec/requests/contributors_spec.rb
+++ b/spec/requests/contributors_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
-describe "Contributors", :type => :request do
-  describe "GET /contributors" do
+describe 'Contributors', type: :request do
+  describe 'GET /contributors' do
     before :each do
       contributors = ([
           {'login' => 'thomas', 'avatar_url' => 'http://example.com/thomas.png', 'html_url' => 'http://github.com/thomas', 'contributions' => 7},
           {'login' => 'john', 'avatar_url' => 'http://example.com/john.png', 'html_url' => 'http://github.com/john', 'contributions' => 9}
       ]).to_json
 
-      stub_request(:get, /api.github.com/).
-          with(:headers => {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
-          to_return(:status => 200, :body => contributors, :headers => {})
+      stub_request(:get, /api.github.com/)
+          .with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'})
+          .to_return(status: 200, body: contributors, headers: {})
     end
-    it "contributors path should return 200" do
+    it 'contributors path should return 200' do
       get contributors_path
       expect(response.code).to eq('200')
     end

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -7,9 +7,9 @@ describe 'Invitations', type: :request, helpers: :requests do
   end
 
   describe 'create -- xhr POST /invitations' do
-    let(:superadmin) {
+    let(:superadmin) do
       FactoryBot.create(:user, email: 'superadmin@example.com', superadmin: true)
-    }
+    end
 
     describe 'batch invites' do
       let(:org) { FactoryBot.create :organisation, email: 'yes@hello.com' }
@@ -32,9 +32,9 @@ describe 'Invitations', type: :request, helpers: :requests do
   end
 
   describe '#invited -- GET /user_reports/invited' do
-    let(:superadmin) {
+    let(:superadmin) do
       FactoryBot.create(:user, email: 'superadmin@example.com', superadmin: true)
-    }
+    end
 
     describe 'User.invited_not_accepted returns users w/o orgs' do
       let(:org) { FactoryBot.create :organisation, email: 'yes@hello.com' }

--- a/spec/requests/moderate_edits_spec.rb
+++ b/spec/requests/moderate_edits_spec.rb
@@ -3,19 +3,19 @@ require 'rails_helper'
 describe 'Proposed Edits Moderation', type: :request, helpers: :requests do
   let(:nonsuperadmin) { FactoryBot.create(:user, superadmin: false) }
   let(:org){FactoryBot.create(:organisation, name: 'Friendly Organisation')}
-  let(:proposed_edit){
+  let(:proposed_edit) do
     FactoryBot.create(
         :proposed_organisation_edit,
         name: 'Different Name',
         organisation: org
-    )
-  }
+      )
+  end
   before { login(nonsuperadmin) }
   it 'nonsuperadmin cannot accept edit' do
-    expect{
+    expect do
       patch organisation_proposed_organisation_edit_path(proposed_edit.organisation, proposed_edit),
         params: {proposed_organisation_edit: {name: 'Different Name', id: proposed_edit.id}}
       org.reload
-    }.not_to change{org.name}
+    end.not_to change{org.name}
   end
 end

--- a/spec/requests/propose_edits_spec.rb
+++ b/spec/requests/propose_edits_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 describe 'Propose an edit', type: :request, helpers: :requests do
   let(:nonsuperadmin) { FactoryBot.create(:user, superadmin: false) }
-  let(:org){
+  let(:org) do
     FactoryBot.create(
         :organisation, name: 'Friendly Organisation',
         address: '34 pinner road',
         telephone: '202',
         email: 'blah@blah.org',
         publish_email: false
-    )
-  }
+      )
+  end
   let(:proposed_edit){FactoryBot.build(:proposed_organisation_edit, organisation: org)}
   before { login(nonsuperadmin) }
 

--- a/spec/requests/propose_organisations_spec.rb
+++ b/spec/requests/propose_organisations_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe "Moderate a proposed org", :type => :request, :helpers => :requests do
+describe 'Moderate a proposed org', type: :request, helpers: :requests do
   let(:nonsuperadmin) { FactoryBot.create(:user, superadmin: false) }
   let!(:proposed_org){FactoryBot.create(:proposed_organisation)}
 

--- a/spec/requests/user_reports_spec.rb
+++ b/spec/requests/user_reports_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
-describe 'UserReports', :type => :request, :helpers => :requests do
-  let(:nonsuperadmin) {FactoryBot.create :user, :email => "nonsuperadmin@nonsuperadmin.com", :superadmin => false}
-  let(:deleted_user) {usr = FactoryBot.create :user , :email => 'regularjoe@blah.com'; usr.destroy; usr}
+describe 'UserReports', type: :request, helpers: :requests do
+  let(:nonsuperadmin) {FactoryBot.create :user, email: 'nonsuperadmin@nonsuperadmin.com', superadmin: false}
+  let(:deleted_user) {usr = FactoryBot.create :user , email: 'regularjoe@blah.com'; usr.destroy; usr}
   let(:pending_org) { FactoryBot.create :organisation }
   let(:user) { FactoryBot.create :user, pending_organisation: pending_org }
 
   describe 'PUT /user_reports/undo_delete/:id' do
     it 'nonsuperadmin unable to undo delete' do
       login(nonsuperadmin)
-      expect {
+      expect do
         put undo_delete_users_report_path(deleted_user.id)
-      }.to change(User, :count).by(0)
+      end.to change(User, :count).by(0)
       expect(response).to redirect_to(root_path)
       follow_redirect!
       expect(response.body).to include I18n.t('authorize.superadmin')
@@ -31,7 +31,7 @@ describe 'UserReports', :type => :request, :helpers => :requests do
   describe 'PUT /user_reports/update/:id, :pending_org_action' do
     it 'nonsuperadmin unable to decline pending org admin' do
       login(nonsuperadmin)
-      put user_report_path(id: user.id, pending_org_action: "decline")
+      put user_report_path(id: user.id, pending_org_action: 'decline')
       expect(response).to redirect_to(root_path)
       follow_redirect!
       expect(response.body).to include I18n.t('authorize.superadmin')

--- a/spec/requests/volunteer_ops_spec.rb
+++ b/spec/requests/volunteer_ops_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe 'VolunteerOps', type: :request, helpers: :requests do
   let(:org_owner) { FactoryBot.create(:user_stubbed_organisation) }
   let(:non_org_owner) { FactoryBot.create :user , email: 'regularjoe@blah.com'}
-  let(:superadmin) {
+  let(:superadmin) do
     FactoryBot.create :user,
                       email: 'superadmin@superadmin.com',
                       superadmin: true
-  }
+  end
 
   describe 'POST /volunteer_ops' do
     let(:params) { { volunteer_op: {title: 'hard work', description: 'for the willing'} } }
@@ -16,9 +16,9 @@ describe 'VolunteerOps', type: :request, helpers: :requests do
       expect_any_instance_of(TwitterApi).to receive(:tweet).once
       org_admin = org_owner
       login(org_admin)
-      expect {
+      expect do
         post organisation_volunteer_ops_path(org_admin.organisation), params: params
-      }.to change(VolunteerOp, :count).by(1)
+      end.to change(VolunteerOp, :count).by(1)
     end
 
     it 'the new VolunteerOp is associated with the requested organisation' do
@@ -32,17 +32,17 @@ describe 'VolunteerOps', type: :request, helpers: :requests do
 
     it 'does not work for non-org-owners' do
       login(non_org_owner)
-      expect {
+      expect do
         post organisation_volunteer_ops_path(org_owner.organisation.id), params: params
-      }.to change(VolunteerOp, :count).by(0)
+      end.to change(VolunteerOp, :count).by(0)
     end
 
     it 'does work for superadmins' do
       expect_any_instance_of(TwitterApi).to receive(:tweet).once
       login(superadmin)
-      expect{
+      expect do
         post organisation_volunteer_ops_path(org_owner.organisation.id), params: params
-      }.to change(VolunteerOp, :count).by(1)
+      end.to change(VolunteerOp, :count).by(1)
     end
   end
 end

--- a/spec/routing/organisations_routing_spec.rb
+++ b/spec/routing/organisations_routing_spec.rb
@@ -1,34 +1,34 @@
-require "rails_helper"
+require 'rails_helper'
 
-describe OrganisationsController, :type => :routing do
-  describe "routing" do
+describe OrganisationsController, type: :routing do
+  describe 'routing' do
 
-    it "recognizes and generates #index" do
-      expect({ :get => "/organisations" }).to route_to(:controller => "organisations", :action => "index")
+    it 'recognizes and generates #index' do
+      expect(get: '/organisations').to route_to(controller: 'organisations', action: 'index')
     end
 
-    it "recognizes and generates #new" do
-      expect({ :get => "/organisations/new" }).to route_to(:controller => "organisations", :action => "new")
+    it 'recognizes and generates #new' do
+      expect(get: '/organisations/new').to route_to(controller: 'organisations', action: 'new')
     end
 
-    it "recognizes and generates #show" do
-      expect({ :get => "/organisations/1" }).to route_to(:controller => "organisations", :action => "show", :id => "1")
+    it 'recognizes and generates #show' do
+      expect(get: '/organisations/1').to route_to(controller: 'organisations', action: 'show', id: '1')
     end
 
-    it "recognizes and generates #edit" do
-      expect({ :get => "/organisations/1/edit" }).to route_to(:controller => "organisations", :action => "edit", :id => "1")
+    it 'recognizes and generates #edit' do
+      expect(get: '/organisations/1/edit').to route_to(controller: 'organisations', action: 'edit', id: '1')
     end
 
-    it "recognizes and generates #create" do
-      expect({ :post => "/organisations" }).to route_to(:controller => "organisations", :action => "create")
+    it 'recognizes and generates #create' do
+      expect(post: '/organisations').to route_to(controller: 'organisations', action: 'create')
     end
 
-    it "recognizes and generates #update" do
-      expect({ :put => "/organisations/1" }).to route_to(:controller => "organisations", :action => "update", :id => "1")
+    it 'recognizes and generates #update' do
+      expect(put: '/organisations/1').to route_to(controller: 'organisations', action: 'update', id: '1')
     end
 
-    it "recognizes and generates #destroy" do
-      expect({ :delete => "/organisations/1" }).to route_to(:controller => "organisations", :action => "destroy", :id => "1")
+    it 'recognizes and generates #destroy' do
+      expect(delete: '/organisations/1').to route_to(controller: 'organisations', action: 'destroy', id: '1')
     end
 
   end

--- a/spec/routing/pages_routing_spec.rb
+++ b/spec/routing/pages_routing_spec.rb
@@ -1,34 +1,34 @@
-require "rails_helper"
+require 'rails_helper'
 
-describe PagesController, :type => :routing do
-  describe "routing" do
+describe PagesController, type: :routing do
+  describe 'routing' do
 
-    it "routes to #index" do
-      expect(get("/pages")).to route_to("pages#index")
+    it 'routes to #index' do
+      expect(get('/pages')).to route_to('pages#index')
     end
 
-    it "routes to #new" do
-      expect(get("/pages/new")).to route_to("pages#new")
+    it 'routes to #new' do
+      expect(get('/pages/new')).to route_to('pages#new')
     end
 
-    it "routes to #show" do
-      expect(get("/1")).to route_to("pages#show", :id => "1")
+    it 'routes to #show' do
+      expect(get('/1')).to route_to('pages#show', id: '1')
     end
 
-    it "routes to #edit" do
-      expect(get("/pages/1/edit")).to route_to("pages#edit", :id => "1")
+    it 'routes to #edit' do
+      expect(get('/pages/1/edit')).to route_to('pages#edit', id: '1')
     end
 
-    it "routes to #create" do
-      expect(post("/pages")).to route_to("pages#create")
+    it 'routes to #create' do
+      expect(post('/pages')).to route_to('pages#create')
     end
 
-    it "routes to #update" do
-      expect(patch("/1")).to route_to("pages#update", :id => "1")
+    it 'routes to #update' do
+      expect(patch('/1')).to route_to('pages#update', id: '1')
     end
 
-    it "routes to #destroy" do
-      expect(delete("/1")).to route_to("pages#destroy", :id => "1")
+    it 'routes to #destroy' do
+      expect(delete('/1')).to route_to('pages#destroy', id: '1')
     end
 
   end

--- a/spec/routing/volunteer_ops_routing_spec.rb
+++ b/spec/routing/volunteer_ops_routing_spec.rb
@@ -1,37 +1,37 @@
-require "rails_helper"
+require 'rails_helper'
 
-describe VolunteerOpsController, :type => :routing do
-  describe "routing" do
+describe VolunteerOpsController, type: :routing do
+  describe 'routing' do
     before :each do
       allow(Feature).to receive(:active?).with(:volunteer_ops).and_return(true)
     end
 
-    it "routes to #index" do
-      expect(get("/volunteer_ops")).to route_to("volunteer_ops#index")
+    it 'routes to #index' do
+      expect(get('/volunteer_ops')).to route_to('volunteer_ops#index')
     end
 
-    it "routes to #new" do
-      expect(get("/organisations/2/volunteer_ops/new")).to route_to("volunteer_ops#new", organisation_id: "2")
+    it 'routes to #new' do
+      expect(get('/organisations/2/volunteer_ops/new')).to route_to('volunteer_ops#new', organisation_id: '2')
     end
 
-    it "routes to #show" do
-      expect(get("/volunteer_ops/1")).to route_to("volunteer_ops#show", :id => "1")
+    it 'routes to #show' do
+      expect(get('/volunteer_ops/1')).to route_to('volunteer_ops#show', id: '1')
     end
 
-    it "routes to #edit" do
-      expect(get("/volunteer_ops/1/edit")).to route_to("volunteer_ops#edit", :id => "1")
+    it 'routes to #edit' do
+      expect(get('/volunteer_ops/1/edit')).to route_to('volunteer_ops#edit', id: '1')
     end
 
-    it "routes to #create" do
-      expect(post("/organisations/2/volunteer_ops")).to route_to("volunteer_ops#create", organisation_id: "2")
+    it 'routes to #create' do
+      expect(post('/organisations/2/volunteer_ops')).to route_to('volunteer_ops#create', organisation_id: '2')
     end
 
-    it "routes to #update" do
-      expect(put("/volunteer_ops/1")).to route_to("volunteer_ops#update", :id => "1")
+    it 'routes to #update' do
+      expect(put('/volunteer_ops/1')).to route_to('volunteer_ops#update', id: '1')
     end
 
-    it "routes to #destroy" do
-      expect(delete("/volunteer_ops/1")).to route_to("volunteer_ops#destroy", :id => "1")
+    it 'routes to #destroy' do
+      expect(delete('/volunteer_ops/1')).to route_to('volunteer_ops#destroy', id: '1')
     end
   end
 end

--- a/spec/services/batch_invite_job_spec.rb
+++ b/spec/services/batch_invite_job_spec.rb
@@ -46,9 +46,7 @@ describe ::BatchInviteJob do
     end
 
     it 'example response for invites with duplicates' do
-      expect(do_batch_invite).to eq(
-        org.id => 'Invited!',
-      )
+      expect(do_batch_invite).to eq( org.id => 'Invited!', (org.id+1) => 'Error: Email has already been taken')
     end
 
     it 'resend invitations to a deleted user' do

--- a/spec/services/batch_invite_job_spec.rb
+++ b/spec/services/batch_invite_job_spec.rb
@@ -47,8 +47,7 @@ describe ::BatchInviteJob do
 
     it 'example response for invites with duplicates' do
       expect(do_batch_invite).to eq(
-        {org.id => 'Invited!',
-         (org.id+1) => 'Error: Email has already been taken'}
+        org.id => 'Invited!',
       )
     end
 
@@ -81,7 +80,7 @@ describe ::BatchInviteJob do
     end
 
     it 'responds with a hash' do
-      expect(subject).to eq({org.id => "Error: Email can't be blank"})
+      expect(subject).to eq(org.id => "Error: Email can't be blank")
     end
   end
 
@@ -91,15 +90,15 @@ describe ::BatchInviteJob do
 
     it 'can be toggled on' do
       params[:resend_invitation] = true
-      expect(answers.(job.call(params))).to eq(['Invited!', 'Invited!'])
-      expect(answers.(job.call(params))).to eq(['Invited!', 'Invited!'])
+      expect(answers.call(job.call(params))).to eq(['Invited!', 'Invited!'])
+      expect(answers.call(job.call(params))).to eq(['Invited!', 'Invited!'])
     end
 
     it 'can be toggled off' do
       params[:resend_invitation] = false
-      expect(answers.(job.call(params))).to eq(['Invited!',
+      expect(answers.call(job.call(params))).to eq(['Invited!',
                                        'Error: Email has already been taken'])
-      expect(answers.(job.call(params))).to eq(['Error: Email has already been taken',
+      expect(answers.call(job.call(params))).to eq(['Error: Email has already been taken',
                                        'Error: Email has already been taken'])
     end
   end

--- a/spec/services/create_flash_for_proposed_organisation_spec.rb
+++ b/spec/services/create_flash_for_proposed_organisation_spec.rb
@@ -46,7 +46,7 @@ describe  CreateFlashForProposedOrganisation do
       let(:email){ 'some_invalid_email.com' }
 
       it 'error flash message is returned' do
-        expect(subject).to match(error: "No invitation email was sent because the email associated with " +
+        expect(subject).to match(error: 'No invitation email was sent because the email associated with ' \
           "#{result.not_accepted_org.name}, #{result.not_accepted_org.email}, seems invalid")
       end
     end

--- a/spec/services/create_organisation_from_array_spec.rb
+++ b/spec/services/create_organisation_from_array_spec.rb
@@ -6,7 +6,7 @@ require_relative '../../app/models/description_humanizer'
 require_relative '../../app/models/first_capitals_humanizer'
 require_relative '../../app/services/create_organisation_from_array'
 
-describe CreateOrganisationFromArray, ".create" do 
+describe CreateOrganisationFromArray, '.create' do 
   let(:mappings) do 
     {name: 'Title',
      address: 'Contact Address',

--- a/spec/services/doit/get_managed_organisations_spec.rb
+++ b/spec/services/doit/get_managed_organisations_spec.rb
@@ -6,18 +6,16 @@ module Doit
     describe '.call' do
       it 'returns list of managed organisation from Doit' do
 
-        stub_request(:get, "http://api.qa2.do-it.org/v2/users/current/orgs?page=1").
-          to_return(:status => 200, :body => File.read('test/fixtures/doit_managed_orgs.json'), :headers => {})
-        stub_request(:get, "http://api.qa2.do-it.org/v2/users/current/orgs?page=2").
-          to_return(:status => 200, :body => File.read('test/fixtures/doit_empty_items.json'), :headers => {})
+        stub_request(:get, 'http://api.qa2.do-it.org/v2/users/current/orgs?page=1')
+          .to_return(status: 200, body: File.read('test/fixtures/doit_managed_orgs.json'), headers: {})
+        stub_request(:get, 'http://api.qa2.do-it.org/v2/users/current/orgs?page=2')
+          .to_return(status: 200, body: File.read('test/fixtures/doit_empty_items.json'), headers: {})
         res = GetManagedOrganisations.call
         
         expect(res).to include(
-          {
             id: '4dd7dfe2-c281-4170-8f0b-da17e8af5e5d',
             name: 'Help Out Harrow!'
-          }
-        )
+          )
       end
     end
   end

--- a/spec/services/doit/post_to_doit_spec.rb
+++ b/spec/services/doit/post_to_doit_spec.rb
@@ -5,8 +5,8 @@ module Doit
 
     describe '.call' do
       it 'create a volunteer op in Doit' do
-        stub_request(:post, "http://api.qa2.do-it.org/v2/opportunities").
-          to_return(:status => 200, :body => File.read('test/fixtures/doit_post_volop.json'), :headers => {'Content-Type' => 'application/json'})
+        stub_request(:post, 'http://api.qa2.do-it.org/v2/opportunities')
+          .to_return(status: 200, body: File.read('test/fixtures/doit_post_volop.json'), headers: {'Content-Type' => 'application/json'})
         vol_op = build(:volunteer_op,
                        latitude: '51.5676116',
                        longitude: '-0.3580085')
@@ -18,8 +18,8 @@ module Doit
       end
 
       it 'handles 400 error responses' do
-        stub_request(:post, "http://api.qa2.do-it.org/v2/opportunities").
-          to_return(:status => 401, :body => File.read('test/fixtures/doit_response_with_error_message.json'), :headers => {'Content-Type' => 'application/json'})
+        stub_request(:post, 'http://api.qa2.do-it.org/v2/opportunities')
+          .to_return(status: 401, body: File.read('test/fixtures/doit_response_with_error_message.json'), headers: {'Content-Type' => 'application/json'})
         vol_op = build :volunteer_op,
                        latitude: '51.5676116',
                        longitude: '-0.3580085'

--- a/spec/services/gmaps/markers_builder_spec.rb
+++ b/spec/services/gmaps/markers_builder_spec.rb
@@ -4,50 +4,59 @@ require 'rails_helper'
 
 describe Gmaps::MarkersBuilder do
 
-  describe "call" do
+  describe 'call' do
     let(:lat) { 40 }
     let(:lng) { 5  }
     let(:id)  { 'id' }
     let(:infowindow) { 'some infowindow content' }
     let(:name)       { 'name' }
-    let(:picture)    { {
-      :url    => "http://www.blankdots.com/img/github-32x32.png",
-      :width  => "32",
-      :height => "32"
-    }}
-    let(:shadow) { {
-      :url    => "shadow",
-      :width  => "30",
-      :height => "30"
-    } }
-    let(:expected_hash) { {
-      :lat          => lat,
-      :lng          => lng,
-      :marker_title => name,
-      :some_id      => id,
-      :infowindow   => infowindow,
-      :picture      => picture,
-      :shadow       => shadow
-    }}
-    let(:object) { OpenStruct.new(
-      :latitude  => lat,
-      :longitude => lng,
-      :name      => name,
-      :some_id   => id
-    )}
+    let(:picture)    do 
+      {
+      url: 'http://www.blankdots.com/img/github-32x32.png',
+      width: '32',
+      height: '32'
+    }
+    end    
+    let(:shadow) do 
+      {
+      url: 'shadow',
+      width: '30',
+      height: '30'
+    }
+    end    
+    let(:expected_hash) do 
+      {
+      lat: lat,
+      lng: lng,
+      marker_title: name,
+      some_id: id,
+      infowindow: infowindow,
+      picture: picture,
+      shadow: shadow
+    }
+    end    
+    let(:object) do 
+      OpenStruct.new(
+      latitude: lat,
+      longitude: lng,
+      name: name,
+      some_id: id
+    )
+    end    
 
-    let(:action) { Gmaps::MarkersBuilder.new(object).call do |user, marker|
+    let(:action) do 
+      Gmaps::MarkersBuilder.new(object).call do |user, marker|
         marker.lat        user.latitude
         marker.lng        user.longitude
         marker.infowindow infowindow
         marker.picture    picture
         marker.shadow     shadow
         marker.title      user.name
-        marker.json({ :some_id => user.some_id })
+        marker.json(some_id: user.some_id)
       end
-    }
+    end
 
-    it "creates expected hash" do
+    it 'creates expected hash' do
       expect(action).to eq [expected_hash]
     end
 

--- a/spec/services/import_doit_opportunities_spec.rb
+++ b/spec/services/import_doit_opportunities_spec.rb
@@ -82,5 +82,4 @@ describe ImportDoItVolunteerOpportunities do
       expect(model_klass).not_to have_received(:find_or_create_by)
     end
   end
-
 end

--- a/spec/services/invite_unregistered_user_from_proposed_org_spec.rb
+++ b/spec/services/invite_unregistered_user_from_proposed_org_spec.rb
@@ -4,7 +4,7 @@ describe InviteUnregisteredUserFromProposedOrg do
   let(:proposed_org){FactoryBot.create(:orphan_proposed_organisation).accept_proposal}
   context 'successful invite' do
 
-    let(:unregistered_email){"unregistered@email.com"}
+    let(:unregistered_email){'unregistered@email.com'}
     let(:subject){InviteUnregisteredUserFromProposedOrg.new(unregistered_email,proposed_org).run}
 
     it 'sends an email' do
@@ -46,7 +46,7 @@ describe InviteUnregisteredUserFromProposedOrg do
   end
 
   context 'no email' do
-    let(:empty_email){""}
+    let(:empty_email){''}
     let(:subject){InviteUnregisteredUserFromProposedOrg.new(empty_email,proposed_org).run}
 
     it 'returns non successful response object' do

--- a/spec/services/map_marker_json_spec.rb
+++ b/spec/services/map_marker_json_spec.rb
@@ -20,7 +20,7 @@ describe MapMarkerJson do
   end
 
   it 'keeps markers with a lat and lng' do
-    expect(_subject { |_,m| m.lat(0) ; m.lng(0) }).to eq [{"lat"=>0, "lng"=>0}]
+    expect(_subject { |_,m| m.lat(0) ; m.lng(0) }).to eq [{'lat'=>0, 'lng'=>0}]
   end
 
   def _subject

--- a/spec/services/queries/organisations_spec.rb
+++ b/spec/services/queries/organisations_spec.rb
@@ -1,46 +1,46 @@
 require 'rails_helper'
 
 describe Queries::Organisations, '::search_by_keyword_and_category' do
-  let!(:category1) { create(:category, :charity_commission_id => 108) }
-  let!(:category2) { create(:category, :charity_commission_id => 205) }
+  let!(:category1) { create(:category, charity_commission_id: 108) }
+  let!(:category2) { create(:category, charity_commission_id: 205) }
   # not initialized!
-  let(:category3) { create(:category, :charity_commission_id => 307) }
+  let(:category3) { create(:category, charity_commission_id: 307) }
 
 
 
   let!(:org1) do
     create(
       :organisation,
-      :email => "",
-      :name => 'Harrow Bereavement Counselling',
-      :description => 'Bereavement Counselling',
-      :address => '64 pinner road',
-      :postcode => 'HA1 4HZ',
-      :donation_info => 'www.harrow-bereavment.co.uk/donate',
+      email: '',
+      name: 'Harrow Bereavement Counselling',
+      description: 'Bereavement Counselling',
+      address: '64 pinner road',
+      postcode: 'HA1 4HZ',
+      donation_info: 'www.harrow-bereavment.co.uk/donate',
     )
   end
 
   let!(:org2) do
     create(
       :organisation,
-      :name => 'Indian Elders Association',
-      :email => "",
-      :description => 'Care for the elderly',
-      :address => '64 pinner road',
-      :postcode => 'HA1 4HZ',
-      :donation_info => 'www.indian-elders.co.uk/donate'
+      name: 'Indian Elders Association',
+      email: '',
+      description: 'Care for the elderly',
+      address: '64 pinner road',
+      postcode: 'HA1 4HZ',
+      donation_info: 'www.indian-elders.co.uk/donate'
     ).tap { |o| o.categories << category1 ; o.categories << category2 }
   end
 
   let!(:org3) do
     create(
       :organisation,
-      :email => "",
-      :name => 'Age UK Elderly',
-      :description => 'Care for older people',
-      :address => '64 pinner road',
-      :postcode => 'HA1 4HZ',
-      :donation_info => 'www.age-uk.co.uk/donate',
+      email: '',
+      name: 'Age UK Elderly',
+      description: 'Care for older people',
+      address: '64 pinner road',
+      postcode: 'HA1 4HZ',
+      donation_info: 'www.age-uk.co.uk/donate',
     ).tap { |o| o.categories  << category1 }
   end
 
@@ -127,7 +127,7 @@ describe Queries::Organisations, '::search_by_keyword_and_category' do
 
   context '#add_recently_updated_and_has_owner' do
     let(:user1) { create(:user) }
-    let(:user2) { create(:user, email: "blah@blah.org") }
+    let(:user2) { create(:user, email: 'blah@blah.org') }
     before do
       org1.update_attributes(updated_at: 2.year.ago)
       org1.users << user1
@@ -138,11 +138,11 @@ describe Queries::Organisations, '::search_by_keyword_and_category' do
       orgs = described_class.add_recently_updated_and_has_owner(Organisation.all)
       orgs.each do |o|
         case o.name
-          when org1.name
+        when org1.name
             expect(o.recently_updated_and_has_owner).to be false
-          when org2.name
+        when org2.name
             expect(o.recently_updated_and_has_owner).to be true
-          when org3.name
+        when org3.name
             expect(o.recently_updated_and_has_owner).to be false
         end
       end

--- a/spec/services/twitter_api_spec.rb
+++ b/spec/services/twitter_api_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe TwitterApi do
   context 'Posting to twitter' do
-    twitter_client = TwitterApi.new()
-    desc = "Volunteer opportunities"
-    long_tweet = "a" * 5000
+    twitter_client = TwitterApi.new
+    desc = 'Volunteer opportunities'
+    long_tweet = 'a' * 5000
     volop = VolunteerOp.new title: long_tweet
 
     it 'should be able to post a long tweet to twitter' do
@@ -13,7 +13,7 @@ RSpec.describe TwitterApi do
     end
 
     it 'should be able to post a short tweet to twitter' do
-      volop.title = "title"
+      volop.title = 'title'
       expect_any_instance_of(Twitter::REST::Client).to receive(:update).once
       twitter_client.tweet volop
     end

--- a/spec/services/users_organisation_decliner_spec.rb
+++ b/spec/services/users_organisation_decliner_spec.rb
@@ -9,28 +9,28 @@ describe UserOrganisationDecliner,'#call'  do
 
   let(:service) {UserOrganisationDecliner.new(listener, user, current_user)}
 
-  it "deletes the pending organisation from the user" do
+  it 'deletes the pending organisation from the user' do
     allow(listener).to receive(:update_message_for_decline_success)
     expect(user.pending_organisation).not_to be_nil
     service.call
     expect(user.pending_organisation).to be_nil
   end
 
-  it "calls update_message_for_decline_success" do
+  it 'calls update_message_for_decline_success' do
     expect(listener).to receive(:update_message_for_decline_success).with(user, pending_org)
     service.call
   end
 
-  context "non-superadmin" do
+  context 'non-superadmin' do
     let(:current_user) {FactoryBot.create(:user, superadmin: false)}
-    it "does not remove the pending org if called by non-superadmin" do
+    it 'does not remove the pending org if called by non-superadmin' do
       allow(listener).to receive(:authorization_failure_for_update)
       expect(user.pending_organisation).not_to be_nil
       service.call
       expect(user.pending_organisation).not_to be_nil
     end
 
-    it "calls authorization_failure_for_update" do
+    it 'calls authorization_failure_for_update' do
       expect(listener).to receive(:authorization_failure_for_update)
       service.call
     end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -1,15 +1,15 @@
 module ControllerHelpers
   def make_current_user_superadmin(superadmin_user=double('user'))
     allow(superadmin_user).to receive(:superadmin?).and_return(true)
-    allow(request.env['warden']).to receive_messages :authenticate! => superadmin_user
+    allow(request.env['warden']).to receive_messages authenticate!: superadmin_user
     allow(controller).to receive(:current_user).and_return(superadmin_user)
     superadmin_user
   end
 
   def make_current_user_nonsuperadmin
-    nonsuperadmin_user = double("User")
+    nonsuperadmin_user = double('User')
     allow(nonsuperadmin_user).to receive(:superadmin?).and_return(false)
-    allow(request.env['warden']).to receive_messages :authenticate! => nonsuperadmin_user
+    allow(request.env['warden']).to receive_messages authenticate!: nonsuperadmin_user
     allow(controller).to receive(:current_user).and_return(nonsuperadmin_user)
     nonsuperadmin_user
   end

--- a/spec/support/geocoder.rb
+++ b/spec/support/geocoder.rb
@@ -1,4 +1,4 @@
-Geocoder.configure(:lookup => :test)
+Geocoder.configure(lookup: :test)
 Geocoder::Lookup::Test.set_default_stub(
   [
     {

--- a/test/fake_google_geocode.rb
+++ b/test/fake_google_geocode.rb
@@ -21,8 +21,8 @@ class FakeGoogleGeocode < Sinatra::Base
       File.open(File.dirname(__FILE__) + '/fixtures/' + file_name, 'rb').read
     # Errno::ENOENT - No such file or directory
     rescue Errno::ENOENT
-      { "results" => [],
-        "status" => "OVER_QUERY_LIMIT" }.to_json
+      { 'results' => [],
+        'status' => 'OVER_QUERY_LIMIT' }.to_json
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-ENV["RAILS_ENV"] = "test"
+ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 


### PR DESCRIPTION
I started playing with rubocop and came to the point with no return (also known as rubocop -a)
So I fixed the couple of methods that started failing.
I disabled the rules for regexp in `rubocop.yml` - there are hunderds of them and I don't think that it's more readable to have parenthesis around regexp, and disabled method lenght with `#rubocop:disable Metrics/MethodLength` on I think 2 which can't be made shorter due to the amount of arguments.
I don't know if you're interested in going through this pr because its looooong, I had some fun doing this.
currently rubocop --lint returns 4 offences and rubocop  90 and all tests passing - one is sometimes failing randomly but even when I use the same seed as when it failed it's still random.