### PR TITLE
Avoid storing location when JSON content is being served

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,7 +43,7 @@ class ApplicationController < ActionController::Base
   # Stores the URL if permitted
   def store_location
     return unless request_controller_is(white_listed) && request_verb_is_get?
-    session[:previous_url] = request.fullpath
+    session[:previous_url] = request.fullpath unless request.format.json?
   end
 
   # Devise hook

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,6 +22,7 @@ describe ApplicationController, :type => :controller, :helpers => :controllers d
 
   it '#store_location stores URLs only when conditions permit' do
     allow(request).to receive_messages :path => 'this/is/a/path'
+    allow(request.format).to receive_messages :json? => true 
 
     allow(controller).to receive_messages :request_controller_is => false
     allow(controller).to receive_messages :request_verb_is_get? => false
@@ -33,6 +34,10 @@ describe ApplicationController, :type => :controller, :helpers => :controllers d
     expect(session[:previous_url]).to be_nil
 
     allow(controller).to receive_messages :request_verb_is_get? => true
+    controller.store_location
+    expect(session[:previous_url]).to be_nil
+
+    allow(request.format).to receive_messages :json? => false 
     controller.store_location
     expect(session[:previous_url]).to eq request.fullpath
   end


### PR DESCRIPTION
This PR resolves the [issue #1003](https://github.com/AgileVentures/LocalSupport/issues/1003), by preventing the controller to update `session[:previous_url]` when the client requests a JSON document.