### PR TITLE
White label banner

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -403,7 +403,6 @@ input[type="text"] {
 
 @media (min-width: 980px) {
     #page-logo {
-        background: url('HCN-long.png') no-repeat;
         display: inline-block;
         height: 72px;
         width: 1200px;
@@ -421,7 +420,6 @@ input[type="text"] {
 
 @media (max-width: 979px) {
     #page-logo {
-        background: url('HCN-small.png') no-repeat;
         display: inline-block;
         height: 135px;
         width: 120px;

--- a/app/assets/stylesheets/page_logo_background.css.erb
+++ b/app/assets/stylesheets/page_logo_background.css.erb
@@ -1,0 +1,10 @@
+@media (min-width: 980px) {
+  #page-logo {
+    background: url(<%= Setting.large_banner_path %>) no-repeat;
+  }
+}
+@media (max-width: 979px) {
+  #page-logo {
+    background: url(<%= Setting.small_banner_path %>) no-repeat;
+  }
+} 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -7,7 +7,9 @@ class Setting < ApplicationRecord
     meta_tag_title: 'Harrow Community Network',
     meta_tag_site: 'Harrow volunteering',
     meta_tag_description: 'Volunteering Network for Harrow Community',
-    open_graph_site: 'Harrow Community Network'
+    open_graph_site: 'Harrow Community Network',
+    large_banner_path: 'HCN-long.png',
+    small_banner_path: 'HCN-small.png'
   }
 
   def self.method_missing(args)


### PR DESCRIPTION
Moves banner background properties to a css erb file.

Now Background can be set with Setting.large_banner_path for large screens and Setting.small_banner_path for smaller screen. 