### PR TITLE
Make table name explicit in services where clause

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -74,12 +74,12 @@ class Service < ApplicationRecord
   end
 
   def self.search_for_text(text)
-    where('description LIKE ? OR name LIKE ?',
+    where('services.description LIKE ? OR services.name LIKE ?',
           "%#{text}%", "%#{text}%")
   end
 
   def self.search_by_category(text)
-    where('description LIKE ? OR name LIKE ?',
+    where('services.description LIKE ? OR services.name LIKE ?',
           "%#{text}%", "%#{text}%")
   end
 


### PR DESCRIPTION
- Fixes the error `PG::AmbiguousColumn: ERROR: column reference "name" is ambiguous` on the services model by using explicit table names on query where clauses.
Fixes #1368 